### PR TITLE
fix badges, images in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stripe::Rails: A Rails Engine for use with [stripe.com](https://stripe.com)
 [![Gem Version](https://badge.fury.io/rb/stripe-rails.png)](http://badge.fury.io/rb/stripe-rails)
-[![Build Status](https://travis-ci.org/thefrontside/stripe-rails.png?branch=master)](https://travis-ci.org/thefrontside/stripe-rails)
+[![Build Status](https://travis-ci.org/Everapps/stripe-rails.png?branch=master)](https://travis-ci.org/Everapps/stripe-rails)
 [![Dependency Status](https://gemnasium.com/thefrontside/stripe-rails.png)](https://gemnasium.com/thefrontside/stripe-rails)
 
 
@@ -349,10 +349,9 @@ See the [complete listing of all stripe events][5], and the [webhook tutorial][6
 
 ## Thanks
 
-<a href="http://thefrontside.net">![The Frontside](http://github.com/cowboyd/therubyracer/raw/master/thefrontside.png)</a>
+<a href="http://frontside.io">![Frontside](http://frontside.io/images/logo.svg)</a>
 
-`Stripe::Rails` was developed fondly by your friends at [The FrontSide][7]. They are available for your custom software development
-needs, including integration with stripe.com.
+`Stripe::Rails` was originally developed with love and fondess by your friends at [Frontside][7]. They are available for your custom software development needs, including integration with stripe.com.
 
 [1]: https://stripe.com/docs/stripe.js
 [2]: https://manage.stripe.com/#account/apikeys


### PR DESCRIPTION
This updates the badges in the readme to point to the new Travis build on the Everapps repo.

The gemnasium dependency badge can be updated once Everapps has an account there (if that's even something you're interested in)

And finally, fixed the Frontside links, and changed the thank you text to indicate that we are no longer the active maintainers.