### PR TITLE
Relax version constraint on stripe gem

### DIFF
--- a/stripe-rails.gemspec
+++ b/stripe-rails.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Stripe::Rails::VERSION
   gem.add_dependency 'rails', '>= 3'
-  gem.add_dependency 'stripe', '< 2'
+  gem.add_dependency 'stripe'
   gem.add_dependency 'responders', '~> 2.0'
 end


### PR DESCRIPTION
It appears appears this was originally added in db9f6eea to get tests
running on Ruby 1.9. This meant that anyone on Ruby 2.x was forced to
use an older version of the stripe gem in order to support a version of
Ruby that reached end of life on 2015-02-23.

stripe-rails itself does not depend on a specific version of the stripe
gem so it's better to relax this constraint. This allows flexibility so
anyone on 1.9 can add a constraint into their applications while not
holding back anyone on a newer version of Ruby.