### PR TITLE
Fix invalid callback event name

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ its parameter:
 module StagingOnly
   include Stripe::Callbacks
 
-  after_charge_created! :only => proc {|charge, evt| unless evt.livemode} do |charge|
+  after_charge_succeeded! :only => proc {|charge, evt| unless evt.livemode} do |charge|
     puts "FAKE DATA, PLEASE IGNORE!"
   end
 end


### PR DESCRIPTION
This PR fixes the invalid event name pointed out in #52 