### PR TITLE
Remove cowboyd as explicit notification recipient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ rvm:
   - 2.3.4
   - 2.2.7
   - 2.1.9
-notifications:
-  email:
-    recipients:
-      - cowboyd@thefrontside.net
 env:
   global:
     - GIT_COMMITTED_AT=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then git log -1 --pretty=format:%ct; else git log -1 --skip 1 --pretty=format:%ct; fi)


### PR DESCRIPTION
This line is redundant since I am a member of this repository, and it
could potentially interfere with other notification settings because it involves
and explicit override.