### PR TITLE
require responders at init

### DIFF
--- a/lib/stripe/rails.rb
+++ b/lib/stripe/rails.rb
@@ -1,3 +1,4 @@
+require 'responders'
 require "stripe/rails/version"
 require 'stripe/engine'
 require 'stripe/configuration_builder'


### PR DESCRIPTION
Fixes

```
app/controllers/stripe/events_controller.rb:4:in `<class:EventsController>': undefined method `respond_to' for Stripe::EventsController:Class (NoMethodError)
Did you mean?  respond_to?
```