### PR TITLE
Stop passing `ActionController::Parameters` to `Stripe::Event.construct_from`

### DIFF
--- a/app/models/stripe/event_dispatch.rb
+++ b/app/models/stripe/event_dispatch.rb
@@ -11,7 +11,7 @@ module Stripe
     def retrieve_stripe_event(params)
       id = params['id']
       if id == 'evt_00000000000000' #this is a webhook test
-        yield Stripe::Event.construct_from(params)
+        yield Stripe::Event.construct_from(params.to_unsafe_h)
       else
         yield Stripe::Event.retrieve(id)
       end

--- a/test/callbacks_spec.rb
+++ b/test/callbacks_spec.rb
@@ -53,6 +53,12 @@ describe Stripe::Callbacks do
         ->{ subject }.must_raise RuntimeError
       end
     end
+
+    describe 'when run from a Stripe webhook test' do
+      before { event['id'] = 'evt_00000000000000' }
+
+      it { subject } # must_not raise error
+    end
   end
 
   describe 'defined without a bang and raising an exception' do


### PR DESCRIPTION
`Stripe::Event.construct_from` takes a hash instead.

fixes #45