### PR TITLE
Fix initializer example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ You are probably using a newer version of the Stripe API. To fix this, please ex
 ```ruby
 # config/initializers/stripe_rails.rb
 
-Stripe.version = '2018-02-05'
+Stripe.api_version = '2018-02-05'
 ```
 
 ## Thanks


### PR DESCRIPTION
The README has a typo in the example initializer code for setting the Stripe api version. The instructions indicate to use `Stripe.api_version` but the example code incorrectly has `Stripe.version`.