### PR TITLE
automatically retrieve api_version when none is given

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,4 +21,5 @@ group :test do
   gem 'poltergeist' # required for system tests
   gem 'phantomjs'   # ditto
   gem 'puma'        # ditto
+  gem 'webmock'
 end

--- a/README.md
+++ b/README.md
@@ -385,25 +385,6 @@ end
 
 The default fixtures come from [the `stripe-ruby-mock` gem](https://github.com/rebelidealist/stripe-ruby-mock/tree/master/lib/stripe_mock/webhook_fixtures).
 
-## Stripe API Notes
-
-### Stripe API >= 2018-02-05 breaks plan builder
-
-If you get the following error message while running `rake stripe:prepare`
-
-```
-rake aborted!
-Stripe::InvalidRequestError: Received unknown parameter: name
-```
-
-You are probably using a newer version of the Stripe API. To fix this, please explicitly set the API by setting `Stripe.api_version` in an initializer. E.g.
-
-```ruby
-# config/initializers/stripe_rails.rb
-
-Stripe.api_version = '2018-02-05'
-```
-
 ## Thanks
 
 <a href="http://frontside.io">![Frontside](http://frontside.io/images/logo.svg)</a>

--- a/gemfiles/rails4.gemfile
+++ b/gemfiles/rails4.gemfile
@@ -16,4 +16,5 @@ group :test do
   gem 'poltergeist'
   gem 'phantomjs', :require => 'phantomjs/poltergeist'
   gem 'puma'
+  gem 'webmock'
 end

--- a/gemfiles/rails5.gemfile
+++ b/gemfiles/rails5.gemfile
@@ -16,4 +16,5 @@ group :test do
   gem 'poltergeist'
   gem 'phantomjs', :require => 'phantomjs/poltergeist'
   gem 'puma'
+  gem 'webmock'
 end

--- a/lib/stripe/plans.rb
+++ b/lib/stripe/plans.rb
@@ -36,7 +36,7 @@ module Stripe
 
       def current_api_version
         Stripe.api_version || begin
-          _, resp = ::Stripe::StripeClient.new.request { Stripe::Plan.all }
+          resp, _ = @stripe_class.request(:get, @stripe_class.resource_url)
           resp.http_headers['stripe-version']
         end
       end

--- a/lib/stripe/plans.rb
+++ b/lib/stripe/plans.rb
@@ -20,6 +20,8 @@ module Stripe
         @trial_period_days = 0
       end
 
+      private
+
       def create_options
         if api_version_after_switch_to_products_in_plans
           default_create_options
@@ -29,8 +31,14 @@ module Stripe
       end
 
       def api_version_after_switch_to_products_in_plans
-        Stripe.api_version &&
-          Date.parse(Stripe.api_version) >= Date.parse('2018-02-05')
+        Date.parse(current_api_version) >= Date.parse('2018-02-05')
+      end
+
+      def current_api_version
+        Stripe.api_version || begin
+          _, resp = ::Stripe::StripeClient.new.request { Stripe::Plan.all }
+          resp.http_headers['stripe-version']
+        end
       end
 
       def default_create_options

--- a/stripe-rails.gemspec
+++ b/stripe-rails.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Stripe::Rails::VERSION
   gem.add_dependency 'rails', '>= 3'
-  gem.add_dependency 'stripe'
+  gem.add_dependency 'stripe', '>= 2'
   gem.add_dependency 'responders'
 end

--- a/test/fixtures/stripe_plans.json
+++ b/test/fixtures/stripe_plans.json
@@ -1,0 +1,24 @@
+{
+  "object": "list",
+  "count": 1,
+  "data": [
+    {
+      "id": "gold",
+      "object": "plan",
+      "amount": 50000,
+      "created": 1503503433,
+      "currency": "usd",
+      "interval": "month",
+      "interval_count": 1,
+      "livemode": false,
+      "nickname": null,
+      "product": "prod_xxxxxxxxx",
+      "trial_period_days": null,
+      "statement_descriptor": null,
+      "name": "Evercondo Fraser",
+      "statement_description": null
+    }
+  ],
+  "has_more": true,
+  "url": "/v1/plans"
+}

--- a/test/fixtures/stripe_plans.json
+++ b/test/fixtures/stripe_plans.json
@@ -1,24 +1,7 @@
 {
   "object": "list",
-  "count": 1,
-  "data": [
-    {
-      "id": "gold",
-      "object": "plan",
-      "amount": 50000,
-      "created": 1503503433,
-      "currency": "usd",
-      "interval": "month",
-      "interval_count": 1,
-      "livemode": false,
-      "nickname": null,
-      "product": "prod_xxxxxxxxx",
-      "trial_period_days": null,
-      "statement_descriptor": null,
-      "name": "Evercondo Fraser",
-      "statement_description": null
-    }
-  ],
-  "has_more": true,
+  "count": 0,
+  "data": [],
+  "has_more": false,
   "url": "/v1/plans"
 }

--- a/test/fixtures/stripe_plans_headers.json
+++ b/test/fixtures/stripe_plans_headers.json
@@ -1,0 +1,16 @@
+{
+  "Server": "nginx",
+  "Date": "Wed, 21 Mar 2018 20:04:56 GMT",
+  "Content-Type": "application/json",
+  "Content-Length": "5807",
+  "Connection": "close",
+  "Access-Control-Allow-Credentials": "true",
+  "Access-Control-Allow-Methods": "GET, POST, HEAD, OPTIONS, DELETE",
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Expose-Headers": "Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required",
+  "Access-Control-Max-Age": "300",
+  "Cache-Control": "no-cache, no-store",
+  "Request-Id": "req_UCuedZo4sKqUXn",
+  "Stripe-Version": "2018-02-05",
+  "Strict-Transport-Security": "max-age=31556926; includeSubDomains; preload"
+}

--- a/test/fixtures/stripe_plans_headers_2017.json
+++ b/test/fixtures/stripe_plans_headers_2017.json
@@ -1,0 +1,16 @@
+{
+  "Server": "nginx",
+  "Date": "Wed, 21 Mar 2018 20:04:56 GMT",
+  "Content-Type": "application/json",
+  "Content-Length": "5807",
+  "Connection": "close",
+  "Access-Control-Allow-Credentials": "true",
+  "Access-Control-Allow-Methods": "GET, POST, HEAD, OPTIONS, DELETE",
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Expose-Headers": "Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required",
+  "Access-Control-Max-Age": "300",
+  "Cache-Control": "no-cache, no-store",
+  "Request-Id": "req_UCuedZo4sKqUXn",
+  "Stripe-Version": "2017-02-05",
+  "Strict-Transport-Security": "max-age=31556926; includeSubDomains; preload"
+}

--- a/test/plan_builder_spec.rb
+++ b/test/plan_builder_spec.rb
@@ -104,9 +104,17 @@ describe 'building plans' do
     end
 
     describe 'uploading' do
+      include FixtureLoader
+
       describe 'when none exists on stripe.com' do
         before do
           Stripe::Plan.stubs(:retrieve).raises(Stripe::InvalidRequestError.new("not found", "id"))
+
+          headers = load_request_fixture('stripe_plans_headers_2017.json')
+
+          stub_request(:get, "https://api.stripe.com/v1/plans").
+            with(headers: { 'Authorization'=>'Bearer XYZ',}).
+            to_return(status: 200, body: load_request_fixture('stripe_plans.json'), headers: JSON.parse(headers))
         end
 
         it 'creates the plan online' do
@@ -164,6 +172,14 @@ describe 'building plans' do
         describe 'when api_version is not set for api versions that support products' do
           before  { Stripe.api_version = nil }
           subject { Stripe::Plans::GOLD.put! }
+
+          before do
+            headers = load_request_fixture('stripe_plans_headers.json')
+
+            stub_request(:get, "https://api.stripe.com/v1/plans").
+              with(headers: { 'Authorization'=>'Bearer XYZ',}).
+              to_return(status: 200, body: load_request_fixture('stripe_plans.json'), headers: JSON.parse(headers))
+          end
 
           it 'creates the plan online' do
             Stripe::Plan.expects(:create).with(

--- a/test/plan_builder_spec.rb
+++ b/test/plan_builder_spec.rb
@@ -107,10 +107,9 @@ describe 'building plans' do
       include FixtureLoader
 
       describe 'when none exists on stripe.com' do
+        let(:headers) { load_request_fixture('stripe_plans_headers_2017.json') }
         before do
           Stripe::Plan.stubs(:retrieve).raises(Stripe::InvalidRequestError.new("not found", "id"))
-
-          headers = load_request_fixture('stripe_plans_headers_2017.json')
 
           stub_request(:get, "https://api.stripe.com/v1/plans").
             with(headers: { 'Authorization'=>'Bearer XYZ',}).
@@ -172,14 +171,7 @@ describe 'building plans' do
         describe 'when api_version is not set for api versions that support products' do
           before  { Stripe.api_version = nil }
           subject { Stripe::Plans::GOLD.put! }
-
-          before do
-            headers = load_request_fixture('stripe_plans_headers.json')
-
-            stub_request(:get, "https://api.stripe.com/v1/plans").
-              with(headers: { 'Authorization'=>'Bearer XYZ',}).
-              to_return(status: 200, body: load_request_fixture('stripe_plans.json'), headers: JSON.parse(headers))
-          end
+          let(:headers) { load_request_fixture('stripe_plans_headers.json') }
 
           it 'creates the plan online' do
             Stripe::Plan.expects(:create).with(

--- a/test/plan_builder_spec.rb
+++ b/test/plan_builder_spec.rb
@@ -161,6 +161,28 @@ describe 'building plans' do
           end
         end
 
+        describe 'when api_version is not set for api versions that support products' do
+          before  { Stripe.api_version = nil }
+          subject { Stripe::Plans::GOLD.put! }
+
+          it 'creates the plan online' do
+            Stripe::Plan.expects(:create).with(
+              :id => :gold,
+              :currency => 'usd',
+              :product => {
+                :name => 'Solid Gold',
+              },
+              :amount => 699,
+              :interval => 'month',
+              :interval_count => 1,
+              :trial_period_days => 0,
+              :metadata => nil,
+              :statement_descriptor => nil
+            )
+
+            subject
+          end
+        end
       end
 
       describe 'when it is already present on stripe.com' do

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -5,6 +5,9 @@ end
 
 require 'minitest/autorun'
 
+require 'webmock/minitest'
+WebMock.disable_net_connect!(allow_localhost: true)
+
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 ENV['STRIPE_SECRET_KEY'] = 'XYZ'

--- a/test/stripe_initializers_spec.rb
+++ b/test/stripe_initializers_spec.rb
@@ -11,6 +11,12 @@ describe "Configuring the stripe engine" do
 
   def rerun_initializers!; initializers.each{|init| init.run(app) }; end
 
+  after do
+    Stripe.api_version = nil
+    Stripe.api_base    = 'https://api.stripe.com'
+    Stripe.api_key     = 'XYZ'
+  end
+
   describe 'Stripe configurations' do
     it "will have valid default values" do
       Stripe.api_base.must_equal          'https://api.stripe.com'

--- a/test/support/fixture_loader.rb
+++ b/test/support/fixture_loader.rb
@@ -1,0 +1,5 @@
+module FixtureLoader
+  def load_request_fixture(name)
+    Pathname.new(__FILE__).join('..', '..', 'fixtures', name).read
+  end
+end


### PR DESCRIPTION
this removes the need for manually setting up the API version for https://github.com/tansengming/stripe-rails/pull/101