### PR TITLE
updates travis to latest rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-- 2.5.0
-- 2.4.3
-- 2.3.6
+- 2.5.1
+- 2.4.4
+- 2.3.7
 addons:
   chrome: stable
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ rvm:
 - 2.5.0
 - 2.4.3
 - 2.3.6
-- 2.2.9
-- 2.1.10
 addons:
   chrome: stable
 env:
@@ -24,10 +22,6 @@ script:
 gemfile:
 - Gemfile
 - gemfiles/rails4.gemfile
-matrix:
-  exclude:
-  - rvm: 2.1.10
-    gemfile: Gemfile
 notifications:
   slack:
     secure: csciM073msTrOOdVYVXdAsrx2sR3Y1BKL0VvlSsYxBJawDa8BFNl6Fw8Uz1V2n4OfnkMvMCME4I3EXsCb4Kl5omnK+7ibeCzzzkCR5VwUs5/vLY7awUfCiihSCqg5ULAp2T1whQJUl5HY9Ot62sujIUX/FUhPzdbCqaKQ7cVkUo=


### PR DESCRIPTION
and drops support for deprecated Ruby versions https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/