### PR TITLE
New attributes for Stripe Billing Plans

### DIFF
--- a/lib/stripe/plans.rb
+++ b/lib/stripe/plans.rb
@@ -13,7 +13,8 @@ module Stripe
                     :nickname,
                     :product_id,
                     :statement_descriptor,
-                    :trial_period_days
+                    :trial_period_days,
+                    :usage_type
 
       validates_presence_of :id, :amount, :currency
 
@@ -23,6 +24,7 @@ module Stripe
 
       validates :statement_descriptor, :length => { :maximum => 22 }
       validates :active, inclusion: { in: [true, false] }, allow_nil: true
+      validates :usage_type, inclusion: { in: ['metered', 'licensed'] }, allow_nil: true
 
       validate :name_or_product_id
 

--- a/lib/stripe/plans.rb
+++ b/lib/stripe/plans.rb
@@ -5,6 +5,7 @@ module Stripe
     configuration_for :plan do
       attr_accessor :active,
                     :amount,
+                    :billing_scheme,
                     :currency,
                     :interval,
                     :interval_count,
@@ -25,6 +26,7 @@ module Stripe
       validates :statement_descriptor, :length => { :maximum => 22 }
       validates :active, inclusion: { in: [true, false] }, allow_nil: true
       validates :usage_type, inclusion: { in: ['metered', 'licensed'] }, allow_nil: true
+      validates :billing_scheme, inclusion: { in: ['per_unit', 'tiered'] }, allow_nil: true
 
       validate :name_or_product_id
 

--- a/lib/stripe/plans.rb
+++ b/lib/stripe/plans.rb
@@ -10,6 +10,7 @@ module Stripe
                     :interval_count,
                     :metadata,
                     :name, 
+                    :nickname,
                     :product_id,
                     :statement_descriptor,
                     :trial_period_days

--- a/lib/stripe/plans.rb
+++ b/lib/stripe/plans.rb
@@ -11,7 +11,8 @@ module Stripe
                     :currency,
                     :metadata,
                     :statement_descriptor,
-                    :product_id
+                    :product_id,
+                    :active
 
       validates_presence_of :id, :amount, :currency
 
@@ -20,6 +21,7 @@ module Stripe
                               :message => "'%{value}' is not one of 'day', 'week', 'month' or 'year'"
 
       validates :statement_descriptor, :length => { :maximum => 22 }
+      validates :active, inclusion: { in: [true, false] }, allow_nil: true
 
       validate :name_or_product_id
 

--- a/lib/stripe/plans.rb
+++ b/lib/stripe/plans.rb
@@ -15,6 +15,7 @@ module Stripe
                     :nickname,
                     :product_id,
                     :statement_descriptor,
+                    :tiers_mode,
                     :trial_period_days,
                     :usage_type
 
@@ -25,10 +26,12 @@ module Stripe
                               :message => "'%{value}' is not one of 'day', 'week', 'month' or 'year'"
 
       validates :statement_descriptor, :length => { :maximum => 22 }
-      validates :active, inclusion: { in: [true, false] }, allow_nil: true
-      validates :usage_type, inclusion: { in: ['metered', 'licensed'] }, allow_nil: true
-      validates :billing_scheme, inclusion: { in: ['per_unit', 'tiered'] }, allow_nil: true
+
+      validates :active,          inclusion: { in: [true, false] }, allow_nil: true
+      validates :usage_type,      inclusion: { in: ['metered', 'licensed'] }, allow_nil: true
+      validates :billing_scheme,  inclusion: { in: ['per_unit', 'tiered'] }, allow_nil: true
       validates :aggregate_usage, inclusion: { in: %w{ sum last_during_period last_ever max } }, allow_nil: true
+      validates :tiers_mode,      inclusion: { in: %w{ graduated volume } }, allow_nil: true
 
       validate :name_or_product_id
       validate :aggregate_usage_must_be_metered, if: ->(p) { p.aggregate_usage.present? }

--- a/lib/stripe/plans.rb
+++ b/lib/stripe/plans.rb
@@ -3,16 +3,16 @@ module Stripe
     include ConfigurationBuilder
 
     configuration_for :plan do
-      attr_accessor :name, 
+      attr_accessor :active,
                     :amount,
+                    :currency,
                     :interval,
                     :interval_count,
-                    :trial_period_days,
-                    :currency,
                     :metadata,
-                    :statement_descriptor,
+                    :name, 
                     :product_id,
-                    :active
+                    :statement_descriptor,
+                    :trial_period_days
 
       validates_presence_of :id, :amount, :currency
 

--- a/lib/stripe/plans.rb
+++ b/lib/stripe/plans.rb
@@ -28,8 +28,8 @@ module Stripe
       validates :statement_descriptor, :length => { :maximum => 22 }
 
       validates :active,          inclusion: { in: [true, false] }, allow_nil: true
-      validates :usage_type,      inclusion: { in: ['metered', 'licensed'] }, allow_nil: true
-      validates :billing_scheme,  inclusion: { in: ['per_unit', 'tiered'] }, allow_nil: true
+      validates :usage_type,      inclusion: { in: %w{ metered licensed } }, allow_nil: true
+      validates :billing_scheme,  inclusion: { in: %w{ per_unit tiered } }, allow_nil: true
       validates :aggregate_usage, inclusion: { in: %w{ sum last_during_period last_ever max } }, allow_nil: true
       validates :tiers_mode,      inclusion: { in: %w{ graduated volume } }, allow_nil: true
 

--- a/test/plan_builder_spec.rb
+++ b/test/plan_builder_spec.rb
@@ -16,6 +16,7 @@ describe 'building plans' do
         plan.usage_type = 'metered'
         plan.billing_scheme = 'per_unit'
         plan.aggregate_usage = 'sum'
+        plan.tiers_mode = 'graduated'
       end
     end
 
@@ -159,6 +160,17 @@ describe 'building plans' do
           plan.amount = 999
           plan.interval = 'month'
           plan.billing_scheme = 'whatever'
+        end
+      }.must_raise Stripe::InvalidConfigurationError
+    end
+
+    it 'denies invalid values for tiers_mode' do
+      lambda {
+        Stripe.plan :broken do |plan|
+          plan.name = 'Acme as a service'
+          plan.amount = 999
+          plan.interval = 'month'
+          plan.tiers_mode = 'whatever'
         end
       }.must_raise Stripe::InvalidConfigurationError
     end

--- a/test/plan_builder_spec.rb
+++ b/test/plan_builder_spec.rb
@@ -11,6 +11,7 @@ describe 'building plans' do
         plan.trial_period_days = 30
         plan.metadata = {:number_of_awesome_things => 5}
         plan.statement_descriptor = 'Acme Primo'
+        plan.active = true
       end
     end
 
@@ -97,6 +98,17 @@ describe 'building plans' do
           plan.amount = 999
           plan.interval = 'month'
           plan.statement_descriptor = 'ACME as a Service Monthly'
+        end
+      }.must_raise Stripe::InvalidConfigurationError
+    end
+
+    it 'denies invalid values for active' do
+      lambda {
+        Stripe.plan :broken do |plan|
+          plan.name = 'Acme as a service'
+          plan.amount = 999
+          plan.interval = 'month'
+          plan.active = 'whatever'
         end
       }.must_raise Stripe::InvalidConfigurationError
     end

--- a/test/plan_builder_spec.rb
+++ b/test/plan_builder_spec.rb
@@ -14,6 +14,7 @@ describe 'building plans' do
         plan.active = true
         plan.nickname = 'primo'
         plan.usage_type = 'licensed'
+        plan.billing_scheme = 'per_unit'
       end
     end
 
@@ -122,6 +123,17 @@ describe 'building plans' do
           plan.amount = 999
           plan.interval = 'month'
           plan.usage_type = 'whatever'
+        end
+      }.must_raise Stripe::InvalidConfigurationError
+    end
+
+    it 'denies invalid values for billing_scheme' do
+      lambda {
+        Stripe.plan :broken do |plan|
+          plan.name = 'Acme as a service'
+          plan.amount = 999
+          plan.interval = 'month'
+          plan.billing_scheme = 'whatever'
         end
       }.must_raise Stripe::InvalidConfigurationError
     end

--- a/test/plan_builder_spec.rb
+++ b/test/plan_builder_spec.rb
@@ -12,6 +12,7 @@ describe 'building plans' do
         plan.metadata = {:number_of_awesome_things => 5}
         plan.statement_descriptor = 'Acme Primo'
         plan.active = true
+        plan.nickname = 'primo'
       end
     end
 

--- a/test/plan_builder_spec.rb
+++ b/test/plan_builder_spec.rb
@@ -13,8 +13,9 @@ describe 'building plans' do
         plan.statement_descriptor = 'Acme Primo'
         plan.active = true
         plan.nickname = 'primo'
-        plan.usage_type = 'licensed'
+        plan.usage_type = 'metered'
         plan.billing_scheme = 'per_unit'
+        plan.aggregate_usage = 'sum'
       end
     end
 
@@ -126,6 +127,30 @@ describe 'building plans' do
         end
       }.must_raise Stripe::InvalidConfigurationError
     end
+
+    it 'denies invalid values for aggregate_usage' do
+      lambda {
+        Stripe.plan :broken do |plan|
+          plan.name = 'Acme as a service'
+          plan.amount = 999
+          plan.interval = 'month'
+          plan.aggregate_usage = 'whatever'
+        end
+      }.must_raise Stripe::InvalidConfigurationError
+    end
+
+    it 'denies aggregate_usage if usage type is liecensed' do
+      lambda {
+        Stripe.plan :broken do |plan|
+          plan.name = 'Acme as a service'
+          plan.amount = 999
+          plan.interval = 'month'
+          plan.usage_type = 'licensed'
+          plan.aggregate_usage = 'sum'
+        end
+      }.must_raise Stripe::InvalidConfigurationError
+    end
+
 
     it 'denies invalid values for billing_scheme' do
       lambda {

--- a/test/plan_builder_spec.rb
+++ b/test/plan_builder_spec.rb
@@ -13,6 +13,7 @@ describe 'building plans' do
         plan.statement_descriptor = 'Acme Primo'
         plan.active = true
         plan.nickname = 'primo'
+        plan.usage_type = 'licensed'
       end
     end
 
@@ -110,6 +111,17 @@ describe 'building plans' do
           plan.amount = 999
           plan.interval = 'month'
           plan.active = 'whatever'
+        end
+      }.must_raise Stripe::InvalidConfigurationError
+    end
+
+    it 'denies invalid values for usage_type' do
+      lambda {
+        Stripe.plan :broken do |plan|
+          plan.name = 'Acme as a service'
+          plan.amount = 999
+          plan.interval = 'month'
+          plan.usage_type = 'whatever'
         end
       }.must_raise Stripe::InvalidConfigurationError
     end


### PR DESCRIPTION
Adds the following attributes:

**active optional**

Whether the plan is currently available for new subscriptions. Defaults to true.

**aggregate_usage optional**

Specifies a usage aggregation strategy for plans of usage_type=metered. Allowed values are sum for summing up all usage during a period, last_during_period for picking the last usage record reported within a period, last_ever for picking the last usage record ever (across period bounds) or max which picks the usage record with the maximum reported usage during a period. Defaults to sum.

**billing_scheme optional**

Describes how to compute the price per period. Either per_unit or tiered. per_unit indicates that the fixed amount (specified in amount) will be charged per unit in quantity (for plans with usage_type=licensed), or per unit of total usage (for plans with usage_type=metered). tiered indicates that the unit pricing will be computed using a tiering strategy as defined using the tiers and tiers_mode attributes.

**nickname optional**

A brief description of the plan, hidden from customers.

**tiers_mode optional**

Defines if the tiering price should be graduated or volume based. In volume-based tiering, the maximum quantity within a period determines the per unit price, in graduated tiering pricing can successively change as the quantity grows.

**usage_type optional**

Configures how the quantity per period should be determined, can be either metered or licensed. licensed will automatically bill the quantity set for a plan when adding it to a subscription, metered will aggregate the total usage based on usage records. Defaults to licensed.

[Reference](https://stripe.com/docs/api#create_plan)