### PR TITLE
Fix ActionController::UnknownFormat

### DIFF
--- a/app/controllers/stripe/events_controller.rb
+++ b/app/controllers/stripe/events_controller.rb
@@ -5,7 +5,7 @@ module Stripe
 
     def create
       @event = dispatch_stripe_event params
-      respond_with @event, :location => nil
+      head :ok
     end
   end
 end


### PR DESCRIPTION
I just started getting a lot of `ActionController::UnknownFormat` errors. I checked out the requests, and maybe Stripe used to be sending `Accept: application/json` headers, but now it's sending `Accept: */*; q=0.5, application/xml`. 

`Stripe::EventsController` only responds to JSON, so it didn't find a valid format when calling `respond_with`. This change makes it explicitly return some JSON. But actually I don't know why it's returning anything? I think it could just use `head :ok` to return an empty 200 response. I looked at the `@event` variable and it was just an empty array `[]`.