### PR TITLE
Allow statement_descriptor to be set on products

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,9 +177,10 @@ end
 As are Products:
 
 ```ruby
-Stripe.products :primo do |products|
-  products.name = 'PRIMO as a service'
-  products.type = 'service'
+Stripe.product :primo do |product|
+  product.name = 'PRIMO as a service'
+  product.type = 'service'
+  product.statement_descriptor = 'PRIMO'
 end
 ```
 

--- a/lib/stripe/products.rb
+++ b/lib/stripe/products.rb
@@ -11,17 +11,23 @@ module Stripe
                     :caption,
                     :metadata,
                     :shippable,
-                    :url
+                    :url,
+                    :statement_descriptor
 
       validates_presence_of :name, :type
 
       validates :active, :shippable, inclusion: { in: [true, false] }, allow_nil: true
       validates :type, inclusion: { in: %w(service good) }
       validates :caption, :description, :shippable, :url, absence: true, unless: :good?
+      validates :statement_descriptor, absence: true, unless: :service?
 
       private
       def good?
         type == 'good'
+      end
+
+      def service?
+        type == 'service'
       end
 
       def create_options
@@ -35,6 +41,7 @@ module Stripe
           metadata: metadata,
           shippable: shippable,
           url: url,
+          statement_descriptor: statement_descriptor
         }.delete_if{|_, v| v.nil? }
       end
     end

--- a/lib/stripe/products.rb
+++ b/lib/stripe/products.rb
@@ -16,6 +16,8 @@ module Stripe
 
       validates_presence_of :name, :type
 
+      validates :statement_descriptor, length: { maximum: 22 }
+
       validates :active, :shippable, inclusion: { in: [true, false] }, allow_nil: true
       validates :type, inclusion: { in: %w(service good) }
       validates :caption, :description, :shippable, :url, absence: true, unless: :good?

--- a/test/product_builder_spec.rb
+++ b/test/product_builder_spec.rb
@@ -87,5 +87,17 @@ describe 'building products' do
         }.must_raise Stripe::InvalidConfigurationError
       end
     end
+
+    describe 'when using an attribute only for services' do
+      it 'raises an exception during configuration' do
+        lambda {
+          Stripe.product :broken do |product|
+            product.name        = 'Broken Good'
+            product.type        = 'good'
+            product.statement_descriptor = 'SERVICE'
+          end
+        }.must_raise Stripe::InvalidConfigurationError
+      end
+    end
   end
 end

--- a/test/product_builder_spec.rb
+++ b/test/product_builder_spec.rb
@@ -8,6 +8,7 @@ describe 'building products' do
       product.active      = true
       product.attributes  = ['size', 'gender']
       product.metadata    = {:number_of_awesome_things => 5}
+      product.statement_descriptor = 'PRIMO'
     end
   end
 
@@ -32,12 +33,13 @@ describe 'building products' do
 
       it 'creates the plan online' do
         Stripe::Product.expects(:create).with(
-          :id => :primo,
-          :name => 'Acme as a service PRIMO',
-          :type => 'service',
-          :active => true,
-          :attributes => ['size', 'gender'],
-          :metadata => {:number_of_awesome_things => 5},
+          id: :primo,
+          name: 'Acme as a service PRIMO',
+          type: 'service',
+          active: true,
+          attributes: ['size', 'gender'],
+          metadata: {:number_of_awesome_things => 5},
+          statement_descriptor: 'PRIMO'
         )
         Stripe::Products::PRIMO.put!
       end


### PR DESCRIPTION
[Creating a Service Product](https://stripe.com/docs/api/curl#create_service_product) allows a [statement_descriptor](https://stripe.com/docs/api/curl#create_service_product-statement_descriptor) to be set for `service` products.

This PR adds statement_descriptor to the products configuration builder and makes sure it is only set for `service` products.