### PR TITLE
Add Webhook Signature Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,32 @@ config.stripe.publishable_key = 'pk_live_XXXYYYZZZ'
 
 This key will be publicly visible on the internet, so it is ok to put in your source.
 
+### Signed Webhooks
+
+Validation of your webhook's signature uses your webhook endpoint signing secret.
+Before you can verify signatures, you need to retrieve your endpoint’s secret your
+Stripe Dashboard. Select an endpoint for which you want to obtain
+the secret, then select the Click to reveal button.
+
+```ruby
+# config/application.rb
+# ...
+config.stripe.signing_secret = 'whsec_XXXYYYZZZ'
+```
+
+Each secret is unique to the endpoint to which it corresponds. If you use multiple endpoints,
+you must obtain a secret for each one. After this setup, Stripe starts to sign each webhook
+it sends to the endpoint. Because of this, we recommend setting this variable with an environment
+variable:
+
+```sh
+export STRIPE_SIGNING_SECRET=whsec_XXXYYYZZZ
+```
+
+```ruby
+config.stripe.signing_secret = ENV.fetch('STRIPE_SIGNING_SECRET')
+```
+
 ### Manually set your API version (optional)
 
 If you need to test a new API version in development, you can override the version number manually.

--- a/README.md
+++ b/README.md
@@ -101,32 +101,6 @@ config.stripe.publishable_key = 'pk_live_XXXYYYZZZ'
 
 This key will be publicly visible on the internet, so it is ok to put in your source.
 
-### Signed Webhooks
-
-Validation of your webhook's signature uses your webhook endpoint signing secret.
-Before you can verify signatures, you need to retrieve your endpoint’s secret your
-Stripe Dashboard. Select an endpoint for which you want to obtain
-the secret, then select the Click to reveal button.
-
-```ruby
-# config/application.rb
-# ...
-config.stripe.signing_secret = 'whsec_XXXYYYZZZ'
-```
-
-Each secret is unique to the endpoint to which it corresponds. If you use multiple endpoints,
-you must obtain a secret for each one. After this setup, Stripe starts to sign each webhook
-it sends to the endpoint. Because of this, we recommend setting this variable with an environment
-variable:
-
-```sh
-export STRIPE_SIGNING_SECRET=whsec_XXXYYYZZZ
-```
-
-```ruby
-config.stripe.signing_secret = ENV.fetch('STRIPE_SIGNING_SECRET')
-```
-
 ### Manually set your API version (optional)
 
 If you need to test a new API version in development, you can override the version number manually.
@@ -237,6 +211,61 @@ config.stripe.endpoint = '/payment/stripe-integration'
 ```
 
 Your new webhook URL would then be `http://myproductionapp/payment/stripe-integration/events`
+
+### Signed Webhooks
+
+Validation of your webhook's signature uses your webhook endpoint signing secret.
+Before you can verify signatures, you need to retrieve your endpoint’s secret your
+Stripe Dashboard. Select an endpoint for which you want to obtain
+the secret, then select the Click to reveal button.
+
+```ruby
+# config/application.rb
+# ...
+config.stripe.signing_secret = 'whsec_XXXYYYZZZ'
+```
+
+Each secret is unique to the endpoint to which it corresponds. If you use multiple endpoints,
+you must obtain a secret for each one. After this setup, Stripe starts to sign each webhook
+it sends to the endpoint. Because of this, we recommend setting this variable with an environment
+variable:
+
+```sh
+export STRIPE_SIGNING_SECRET=whsec_XXXYYYZZZ
+```
+
+```ruby
+config.stripe.signing_secret = ENV.fetch('STRIPE_SIGNING_SECRET')
+```
+
+#### Testing Signed Webhooks Locally
+
+In order to test signed webhooks, you'll need to trigger test webhooks from your Stripe dashboard,
+and configure your local environment to receive remote network requests. To do so, we recommend using
+[ngrok](https://ngrok.com/) to configure a secure tunnel to `localhost`.
+
+Once configured and running, `ngrok` will give you a unique URL which can be used to set up a webhook
+endpoint. Webhook endpoints are configured in your Dashboard's [Webhook settings](https://dashboard.stripe.com/account/webhooks)
+section. Make sure you are in **Test** mode and click `Add endpoint`, and provide your `ngrok` URL along with the `stripe.endpoint` suffix.
+
+An example webhook URL would then be `https://bf2a5d21.ngrok.io/stripe/events`.
+
+Once your endpoint is configured, you can reveal the **Signing secret**. This will need to be set
+as documented above:
+
+```ruby
+# config/application.rb
+# ...
+config.stripe.signing_secret = 'whsec_XXXYYYZZZ'
+```
+
+And you'll need to restart your rails server with:
+
+```sh
+rails restart
+```
+
+Now you're ready to click **Send test webhook**, and trigger whichever events you'd like to test from Stripe itself.
 
 ### Disabling auto mount
 

--- a/app/controllers/stripe/events_controller.rb
+++ b/app/controllers/stripe/events_controller.rb
@@ -4,8 +4,14 @@ module Stripe
     respond_to :json
 
     def create
-      @event = dispatch_stripe_event params
+      @event = dispatch_stripe_event(request)
       head :ok
+    rescue JSON::ParserError => e
+      ::Rails.logger.error e.message
+      head :bad_request, status: 400
+    rescue Stripe::SignatureVerificationError => e
+      ::Rails.logger.error e.message
+      head :bad_request, status: 400
     end
   end
 end

--- a/lib/stripe/engine.rb
+++ b/lib/stripe/engine.rb
@@ -8,7 +8,7 @@ module Stripe
       attr_accessor :testing
     end
 
-    stripe_config = config.stripe = Struct.new(:api_base, :api_version, :secret_key, :verify_ssl_certs, :publishable_key, :endpoint, :debug_js, :auto_mount, :eager_load, :open_timeout, :read_timeout).new
+    stripe_config = config.stripe = Struct.new(:api_base, :api_version, :secret_key, :verify_ssl_certs, :signing_secret, :publishable_key, :endpoint, :debug_js, :auto_mount, :eager_load, :open_timeout, :read_timeout).new
 
     def stripe_config.api_key=(key)
       warn "[DEPRECATION] to align with stripe nomenclature, stripe.api_key has been renamed to config.stripe.secret_key"

--- a/test/events_controller_spec.rb
+++ b/test/events_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Stripe::EventsController do
-  parallelize_me!
   include Rack::Test::Methods
 
   let(:app) { Rails.application }
@@ -26,7 +25,10 @@ describe Stripe::EventsController do
   describe 'signed webhooks' do
     before do
       header 'Stripe-Signature', 't=1537832721,v1=123,v0=123'
+      app.config.stripe.signing_secret = 'SECRET'
     end
+
+    after { app.config.stripe.signing_secret = nil }
 
     let(:params) {
       {

--- a/test/events_controller_spec.rb
+++ b/test/events_controller_spec.rb
@@ -11,7 +11,7 @@ describe Stripe::EventsController do
   end
 
   describe 'the events interface' do
-    let(:params) { 
+    let(:params) {
       {
         id: 'evt_00000000000000',
         type: 'customer.updated',
@@ -21,5 +21,34 @@ describe Stripe::EventsController do
     subject { post '/stripe/events', params.to_json }
 
     it { subject.must_be :ok? }
+  end
+
+  describe 'signed webhooks' do
+    before do
+      header 'Stripe-Signature', 't=1537832721,v1=123,v0=123'
+    end
+
+    let(:params) {
+      {
+        id: 'evt_00000000000001',
+        type: 'customer.updated',
+        data: {
+          object: 'customer',
+          fingerprint: 'xxxyyyzzz'
+        },
+      }
+    }
+
+    subject { post '/stripe/events', params.to_json }
+
+    it 'returns bad_request when invalid' do
+      Stripe::Webhook.expects(:construct_event).raises(Stripe::SignatureVerificationError.new('msg', 'sig_header'))
+      subject.must_be :bad_request?
+    end
+
+    it 'returns ok when valid' do
+      Stripe::Webhook.expects(:construct_event).returns(Stripe::Event.construct_from(params))
+      subject.must_be :ok?
+    end
   end
 end

--- a/test/stripe_initializers_spec.rb
+++ b/test/stripe_initializers_spec.rb
@@ -34,6 +34,7 @@ describe "Configuring the stripe engine" do
     subject do
       app.config.stripe.api_base          = 'http://localhost:5000'
       app.config.stripe.secret_key        = 'SECRET_XYZ'
+      app.config.stripe.signing_secret    = 'SIGNING_SECRET_XYZ'
       app.config.stripe.verify_ssl_certs  = false
       app.config.stripe.api_version       = '2015-10-16'
       app.config.stripe.open_timeout      = 33
@@ -50,6 +51,8 @@ describe "Configuring the stripe engine" do
       Stripe.api_version.must_equal       '2015-10-16'
       Stripe.open_timeout.must_equal      33
       Stripe.read_timeout.must_equal      88
+
+      app.config.stripe.signing_secret.must_equal   'SIGNING_SECRET_XYZ'
     end
   end
 


### PR DESCRIPTION
This PR updates the `retrieve_stripe_event` method to validate the Webhook's signature according to [the documentation](https://stripe.com/docs/webhooks/signatures). This check eliminates the network request currently used to retrieve the `Stripe::Event` model, and enables the use of test webhooks through the Stripe dashboard (currently test Events are not stored and thus cannot be retrieved, resulting in a 500 error).

This PR should be fully backwards compatible, and will only use the `Stripe::Webhook.construct_event` if it is both a) defined and b) configured correctly. Otherwise it falls back to the current behavior.