### PR TITLE
fixes undefined method `expand_path' for Stripe::File:Class.

### DIFF
--- a/lib/generators/stripe/install_generator.rb
+++ b/lib/generators/stripe/install_generator.rb
@@ -1,6 +1,6 @@
 module Stripe
   class InstallGenerator < ::Rails::Generators::Base
-    source_root File.expand_path("../../templates", __FILE__)
+    source_root ::File.expand_path("../../templates", __FILE__)
 
     desc "copy plans.rb"
     def copy_plans_file


### PR DESCRIPTION
First reported at https://github.com/tansengming/stripe-rails/issues/127