### PR TITLE
Change .products to .product

### DIFF
--- a/lib/generators/templates/products.rb
+++ b/lib/generators/templates/products.rb
@@ -3,12 +3,12 @@
 # Example
 # Stripe::Products::PRIMO #=> 'primo'
 
-# Stripe.products :primo do |products|
-#   # products name as it will appear on credit card statements
-#   products.name = 'Acme as a service PRIMO'
+# Stripe.product :primo do |product|
+#   # product's name as it will appear on credit card statements
+#   product.name = 'Acme as a service PRIMO'
 #
 #   # Product, either 'service' or 'good'
-#   products.type = 'service'
+#   product.type = 'service'
 # end
 
 # Once you have your productss defined, you can run


### PR DESCRIPTION
<!--
  Please give us ~1 week to get back to you.
  If you'd like to receive occasional updates, sign up for our newsletter at http://tinyletter.com/stripe-rails
-->

The template for product configuration uses `Stripe.products` when it should be `Stripe.product`. This causes an error when running `rake stripe:prepare`.

I've gone ahead and added the fix in this PR. Thanks for building stripe-rails!

