### PR TITLE
Add usage_type, aggregate_usage, and billing_scheme.

### DIFF
--- a/lib/stripe/configuration_builder.rb
+++ b/lib/stripe/configuration_builder.rb
@@ -76,7 +76,7 @@ module Stripe
         if exists?
           puts "[EXISTS] - #{@stripe_class}:#{@id}" unless Stripe::Engine.testing
         else
-          object = @stripe_class.create({:id => @id}.merge create_options)
+          object = @stripe_class.create({:id => @id}.merge compact_create_options)
           puts "[CREATE] - #{@stripe_class}:#{object}" unless Stripe::Engine.testing
         end
       end
@@ -85,8 +85,12 @@ module Stripe
         if object = exists?
           object.delete
         end
-        object = @stripe_class.create({:id => @id}.merge create_options)
+        object = @stripe_class.create({:id => @id}.merge compact_create_options)
         puts "[RESET] - #{@stripe_class}:#{object}" unless Stripe::Engine.testing
+      end
+
+      def compact_create_options
+        create_options.delete_if { |_, v| v.nil? }
       end
 
       def to_s

--- a/lib/stripe/plans.rb
+++ b/lib/stripe/plans.rb
@@ -69,6 +69,9 @@ module Stripe
           interval_count: interval_count,
           trial_period_days: trial_period_days,
           metadata: metadata,
+          usage_type: usage_type,
+          aggregate_usage: aggregate_usage,
+          billing_scheme: billing_scheme,
           nickname: nickname
         }.delete_if{|_, v| v.nil? }
       end
@@ -86,6 +89,9 @@ module Stripe
           interval_count: interval_count,
           trial_period_days: trial_period_days,
           metadata: metadata,
+          usage_type: usage_type,
+          aggregate_usage: aggregate_usage,
+          billing_scheme: billing_scheme,
           statement_descriptor: statement_descriptor
         }.delete_if{|_, v| v.nil? }
       end

--- a/lib/stripe/plans.rb
+++ b/lib/stripe/plans.rb
@@ -73,7 +73,7 @@ module Stripe
           aggregate_usage: aggregate_usage,
           billing_scheme: billing_scheme,
           nickname: nickname
-        }.delete_if{|_, v| v.nil? }
+        }
       end
 
       def product_options
@@ -93,7 +93,7 @@ module Stripe
           aggregate_usage: aggregate_usage,
           billing_scheme: billing_scheme,
           statement_descriptor: statement_descriptor
-        }.delete_if{|_, v| v.nil? }
+        }
       end
     end
   end

--- a/lib/stripe/plans.rb
+++ b/lib/stripe/plans.rb
@@ -54,7 +54,7 @@ module Stripe
 
       def create_options
         if CurrentApiVersion.after_switch_to_products_in_plans?
-          default_create_options
+          create_options_with_products
         else
           create_options_without_products
         end
@@ -63,7 +63,6 @@ module Stripe
       def default_create_options
         {
           currency: currency,
-          product: product_options,
           amount: amount,
           interval: interval,
           interval_count: interval_count,
@@ -80,20 +79,14 @@ module Stripe
         product_id.presence || { name: name, statement_descriptor: statement_descriptor }
       end
 
+      def create_options_with_products
+        default_create_options.merge({ product: product_options })
+                              .delete_if{|_, v| v.nil? }
+      end
+
       def create_options_without_products
-        {
-          currency: currency,
-          name: name,
-          amount: amount,
-          interval: interval,
-          interval_count: interval_count,
-          trial_period_days: trial_period_days,
-          metadata: metadata,
-          usage_type: usage_type,
-          aggregate_usage: aggregate_usage,
-          billing_scheme: billing_scheme,
-          statement_descriptor: statement_descriptor
-        }.delete_if{|_, v| v.nil? }
+        default_create_options.merge(product_options)
+                              .delete_if{|_, v| v.nil? }
       end
     end
   end

--- a/lib/stripe/plans.rb
+++ b/lib/stripe/plans.rb
@@ -80,6 +80,8 @@ module Stripe
         product_id.presence || { name: name, statement_descriptor: statement_descriptor }
       end
 
+      # Note: these options serve an older API, as such they should
+      # probably never be updated.
       def create_options_without_products
         {
           currency: currency,
@@ -89,9 +91,6 @@ module Stripe
           interval_count: interval_count,
           trial_period_days: trial_period_days,
           metadata: metadata,
-          usage_type: usage_type,
-          aggregate_usage: aggregate_usage,
-          billing_scheme: billing_scheme,
           statement_descriptor: statement_descriptor
         }
       end

--- a/lib/stripe/plans.rb
+++ b/lib/stripe/plans.rb
@@ -54,7 +54,7 @@ module Stripe
 
       def create_options
         if CurrentApiVersion.after_switch_to_products_in_plans?
-          create_options_with_products
+          default_create_options
         else
           create_options_without_products
         end
@@ -63,6 +63,7 @@ module Stripe
       def default_create_options
         {
           currency: currency,
+          product: product_options,
           amount: amount,
           interval: interval,
           interval_count: interval_count,
@@ -79,14 +80,20 @@ module Stripe
         product_id.presence || { name: name, statement_descriptor: statement_descriptor }
       end
 
-      def create_options_with_products
-        default_create_options.merge({ product: product_options })
-                              .delete_if{|_, v| v.nil? }
-      end
-
       def create_options_without_products
-        default_create_options.merge(product_options)
-                              .delete_if{|_, v| v.nil? }
+        {
+          currency: currency,
+          name: name,
+          amount: amount,
+          interval: interval,
+          interval_count: interval_count,
+          trial_period_days: trial_period_days,
+          metadata: metadata,
+          usage_type: usage_type,
+          aggregate_usage: aggregate_usage,
+          billing_scheme: billing_scheme,
+          statement_descriptor: statement_descriptor
+        }.delete_if{|_, v| v.nil? }
       end
     end
   end

--- a/lib/stripe/products.rb
+++ b/lib/stripe/products.rb
@@ -44,7 +44,7 @@ module Stripe
           shippable: shippable,
           url: url,
           statement_descriptor: statement_descriptor
-        }.delete_if{|_, v| v.nil? }
+        }
       end
     end
   end

--- a/test/dummy/config/stripe/plans.rb
+++ b/test/dummy/config/stripe/plans.rb
@@ -10,3 +10,12 @@ Stripe.plan :alternative_currency do |plan|
    plan.interval = 'month'
    plan.currency = 'cad'
 end
+
+Stripe.plan :metered do |plan|
+  plan.name = 'Metered'
+  plan.amount = 699
+  plan.interval = 'month'
+  plan.usage_type = 'metered'
+  plan.aggregate_usage = 'max'
+  plan.billing_scheme = 'per_unit'
+end

--- a/test/plan_builder_spec.rb
+++ b/test/plan_builder_spec.rb
@@ -223,6 +223,22 @@ describe 'building plans' do
           Stripe::Plans::GOLD.put!
         end
 
+        it 'creates a metered plan' do
+          Stripe::Plan.expects(:create).with(
+            :id => :metered,
+            :currency => 'usd',
+            :name => 'Metered',
+            :amount => 699,
+            :interval => 'month',
+            :interval_count => 1,
+            :trial_period_days => 0,
+            :usage_type => 'metered',
+            :aggregate_usage => 'max',
+            :billing_scheme => 'per_unit'
+          )
+          Stripe::Plans::METERED.put!
+        end
+
         it 'creates a plan with an alternative currency' do
           Stripe::Plan.expects(:create).with(
             :id => :alternative_currency,

--- a/test/plan_builder_spec.rb
+++ b/test/plan_builder_spec.rb
@@ -223,22 +223,6 @@ describe 'building plans' do
           Stripe::Plans::GOLD.put!
         end
 
-        it 'creates a metered plan' do
-          Stripe::Plan.expects(:create).with(
-            :id => :metered,
-            :currency => 'usd',
-            :name => 'Metered',
-            :amount => 699,
-            :interval => 'month',
-            :interval_count => 1,
-            :trial_period_days => 0,
-            :usage_type => 'metered',
-            :aggregate_usage => 'max',
-            :billing_scheme => 'per_unit'
-          )
-          Stripe::Plans::METERED.put!
-        end
-
         it 'creates a plan with an alternative currency' do
           Stripe::Plan.expects(:create).with(
             :id => :alternative_currency,
@@ -271,6 +255,26 @@ describe 'building plans' do
             )
             Stripe::Plans::GOLD.put!
           end
+
+          it 'creates a metered plan' do
+            Stripe::Plan.expects(:create).with(
+              :id => :metered,
+              :currency => 'usd',
+              :product => {
+                :name => 'Metered',
+                :statement_descriptor => nil,
+              },
+              :amount => 699,
+              :interval => 'month',
+              :interval_count => 1,
+              :trial_period_days => 0,
+              :usage_type => 'metered',
+              :aggregate_usage => 'max',
+              :billing_scheme => 'per_unit'
+            )
+            Stripe::Plans::METERED.put!
+          end
+
 
           describe 'when using a product id' do
             before do


### PR DESCRIPTION
<!--
  Please give us ~1 week to get back to you.
  If you'd like to receive occasional updates, sign up for our newsletter at http://tinyletter.com/stripe-rails
-->

After trying to create a metered plan using the `usage_type` configuration parameter, I noticed that a `licensed` plan was actually created in Stripe. It turns out that a few options were not being passed through, including `usage_type`, `aggregate_usage`, and `billing_scheme`, when pulling together the data to send to Stripe.

This now works for me, but I'm not sure the best way to test the new implementation. @tansengming how would you approach testing it?