### PR TITLE
Clear callbacks whenever files are changed during dev / test, to fix issue with Spring

### DIFF
--- a/lib/stripe/engine.rb
+++ b/lib/stripe/engine.rb
@@ -41,6 +41,17 @@ environment file directly.
       MSG
     end
 
+    initializer 'stripe.callbacks.clear_after_unload' do |app|
+      # Skip Rails 4 for now.
+      next unless app.respond_to?(:reloader)
+
+      # Clear callbacks after all autoloaded classes are removed.
+      # This prevents duplicate callbacks being added during development.
+      app.reloader.after_class_unload do
+        ::Stripe::Callbacks.clear_callbacks!
+      end
+    end
+
     initializer 'stripe.callbacks.eager_load' do |app|
       app.config.after_initialize do
         app.config.stripe.eager_load.each do |constant|


### PR DESCRIPTION
Fixes #136.

Spring doesn't provide any hooks for reloaded files, so I used the listen gem for this. Before this, I would always have to run `spring stop` whenever I changed a model, because Spring would reload the models and add duplicate callbacks for `stripe-rails`. Everything works for me after this change, and my tests always start very quickly.  

If people are not using Spring, then this change will do nothing. (I call: `defined? ::Spring::Application && defined? Listen`)

One very minor issue: I was able to trigger a race condition when I saved a file right when the tests started. This cleared all the callbacks after Spring had already reloaded the models, so my tests failed. But it worked when I ran the tests a second time.