### PR TITLE
Removes text options from Stripe elements helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,12 +252,15 @@ Stripe::Rails comes bundled with default CSS and Javascript for Stripe elements,
 
 If you decide to use your own CSS and Javascript for Stripe Elements, please refer to the [Stripe elements docs](https://stripe.com/docs/stripe-js/elements/quickstart).
 
-You can also configure the form text:
+To change the form text you can add the following keys to your locale files
 
-```erb
-<%= stripe_elements_tag submit_path: billing_path,
-                        label_text: "Your label text",
-                        submit_button_text: "Your button text" %>
+```yaml
+# config/locales/en.yml
+en:
+  stripe_rails:
+    elements:
+      label_text: Your label text
+      submit_button_text: Your button text
 ```
 
 ## Webhooks

--- a/app/helpers/stripe/javascript_helper.rb
+++ b/app/helpers/stripe/javascript_helper.rb
@@ -8,15 +8,14 @@ module Stripe
       render 'stripe/js', stripe_js_version: stripe_js_version
     end
 
-    def stripe_elements_tag(submit_path:, label_text: t("stripe_rails.elements.label_text"),
-                            submit_button_text: t("stripe_rails.elements.submit_button_text"),
+    def stripe_elements_tag(submit_path:,
                             css_path: asset_path("stripe_elements.css"),
                             js_path: asset_path("stripe_elements.js"))
 
       render partial: 'stripe/elements', locals: {
         submit_path: submit_path,
-        label_text: label_text,
-        submit_button_text: submit_button_text,
+        label_text: t('stripe_rails.elements.label_text'),
+        submit_button_text: t('stripe_rails.elements.submit_button_text'),
         css_path: css_path,
         js_path: js_path
       }

--- a/test/javascript_helper_spec.rb
+++ b/test/javascript_helper_spec.rb
@@ -76,19 +76,6 @@ describe Stripe::JavascriptHelper do
           ).wont_include '<style>'
         end
       end
-
-      describe 'text options' do
-        it 'should display the selected text options' do
-          page = view.stripe_elements_tag(
-            submit_path: '/charge',
-            label_text: 'Enter your info',
-            submit_button_text: 'Confirm payment'
-          )
-
-          page.must_include 'Enter your info'
-          page.must_include 'Confirm payment'
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
Having this feature means that folks have 2 ways to update form text,

1. through the helper,
2. with a locale file,

overriding the text through the helper might also show the wrong locale so it feels like an incomplete feature.

For example, if the app is running on the `es` locale while it's getting overridden with English text then it will be broken.

I think it's best to stick with convention and only give folks the option to change the form text through locale files.

This feature has not been released so I'm not too worried about backwards compatibility.

Related to https://github.com/tansengming/stripe-rails/pull/134