### PR TITLE
add support for Plan to use a constant name different from plan id

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,19 @@ create  config/stripe/plans.rb
 create  config/stripe/coupons.rb
 ```
 
+If you have to support an existing plan with a Stripe plan id that can not
+be used as a Ruby constant, define the plan with the name you want to use as a
+Symbol, then provide the name for the constant to define with `constant_name`:
+
+```ruby
+Stripe.plan "Silver Plan".to_sym do |plan|
+  plan.constant_name = :silver_plan
+end
+
+Stripe::Plans::SILVER_PLAN # => will be defined
+# Will map to plan :id => "Silver Plan" on Stripe
+```
+
 ### Configuring your plans and coupons
 
 Use the plan builder to define as many plans as you want in `config/stripe/plans.rb`

--- a/README.md
+++ b/README.md
@@ -161,17 +161,23 @@ create  config/stripe/coupons.rb
 ```
 
 If you have to support an existing plan with a Stripe plan id that can not
-be used as a Ruby constant, define the plan with the name you want to use as a
-Symbol, then provide the name for the constant to define with `constant_name`:
+be used as a Ruby constant, provide the plan id as a symbol when
+defining the plan, but provide the name for the constant to define with `constant_name`:
 
 ```ruby
-Stripe.plan "Silver Plan".to_sym do |plan|
-  plan.constant_name = :silver_plan
+Stripe.plan "Silver-Plan".to_sym do |plan|
+  plan.constant_name = 'SILVER_PLAN'
 end
 
 Stripe::Plans::SILVER_PLAN # => will be defined
-# Will map to plan :id => "Silver Plan" on Stripe
+# Will map to plan :id => "Silver-Plan" on Stripe
 ```
+
+**Note** - If you're planning on running `rake stripe:prepare` to
+  create your subscription plans, Stripe will restrict plan ids to match
+  this regexp (`/\A[a-zA-Z0-9_\-]+\z/`) when created via API but still
+  allows creation of plan ids that don't follow this restriction when
+  manually created on stripe.com.
 
 ### Configuring your plans and coupons
 

--- a/lib/stripe/configuration_builder.rb
+++ b/lib/stripe/configuration_builder.rb
@@ -69,7 +69,7 @@ module Stripe
 
       def globalize!
         id_to_use = @constant_name || @id
-        @stripe_configuration_class[id_to_use.to_s] = self
+        @stripe_configuration_class[id_to_use.to_s.downcase] = self
         @stripe_configuration_class.const_set(id_to_use.to_s.upcase, self)
       end
 

--- a/lib/stripe/configuration_builder.rb
+++ b/lib/stripe/configuration_builder.rb
@@ -68,8 +68,9 @@ module Stripe
       end
 
       def globalize!
-        @stripe_configuration_class[@id.to_s] = self
-        @stripe_configuration_class.const_set(@id.to_s.upcase, self)
+        id_to_use = @constant_name || @id
+        @stripe_configuration_class[id_to_use.to_s] = self
+        @stripe_configuration_class.const_set(id_to_use.to_s.upcase, self)
       end
 
       def put!

--- a/test/dummy/config/stripe/plans.rb
+++ b/test/dummy/config/stripe/plans.rb
@@ -4,6 +4,13 @@ Stripe.plan :gold do |plan|
    plan.interval = 'month'
 end
 
+Stripe.plan "Solid Gold".to_sym do |plan|
+   plan.constant_name = :solid_gold
+   plan.name = 'Solid Gold'
+   plan.amount = 699
+   plan.interval = 'month'
+end
+
 Stripe.plan :alternative_currency do |plan|
    plan.name = 'Alternative Currency'
    plan.amount = 699

--- a/test/dummy/config/stripe/plans.rb
+++ b/test/dummy/config/stripe/plans.rb
@@ -5,7 +5,7 @@ Stripe.plan :gold do |plan|
 end
 
 Stripe.plan "Solid Gold".to_sym do |plan|
-   plan.constant_name = :solid_gold
+   plan.constant_name = 'SOLID_GOLD'
    plan.name = 'Solid Gold'
    plan.amount = 699
    plan.interval = 'month'

--- a/test/plan_builder_spec.rb
+++ b/test/plan_builder_spec.rb
@@ -346,4 +346,81 @@ describe 'building plans' do
       proc {Stripe.plan(:bad) {}}.must_raise Stripe::InvalidConfigurationError
     end
   end
+  
+  describe 'with custom constant name' do
+    before do
+      Stripe.plan "Primo Plan".to_sym do |plan|
+        plan.name = 'Acme as a service PRIMO'
+        plan.constant_name = :primo_plan
+        plan.amount = 699
+        plan.interval = 'month'
+        plan.interval_count = 3
+        plan.trial_period_days = 30
+        plan.metadata = {:number_of_awesome_things => 5}
+        plan.statement_descriptor = 'Acme Primo'
+        plan.active = true
+        plan.nickname = 'primo'
+        plan.usage_type = 'metered'
+        plan.billing_scheme = 'per_unit'
+        plan.aggregate_usage = 'sum'
+        plan.tiers_mode = 'graduated'
+      end
+    end
+
+    after { Stripe::Plans.send(:remove_const, :PRIMO_PLAN) }
+
+    it 'is accessible via upcased constant_name' do
+      Stripe::Plans::PRIMO_PLAN.wont_be_nil
+    end
+
+    it 'is accessible via collection' do
+      Stripe::Plans.all.must_include Stripe::Plans::PRIMO_PLAN
+    end
+
+    it 'is accessible via hash lookup (symbol/string agnostic)' do
+      Stripe::Plans[:primo_plan].must_equal Stripe::Plans::PRIMO_PLAN
+      Stripe::Plans['primo_plan'].must_equal Stripe::Plans::PRIMO_PLAN
+    end
+
+    describe 'constant name validation' do
+      it 'should be invalid when providing a constant name that can not be used for Ruby constant' do
+        lambda {
+          Stripe.plan "Primo Plan".to_sym do |plan|
+            plan.name = 'Acme as a service PRIMO'
+            plan.constant_name = "Primo Plan".to_sym
+            plan.amount = 999
+            plan.interval = 'month'
+          end
+        }.must_raise Stripe::InvalidConfigurationError
+      end
+    end
+
+    describe 'uploading' do
+      include FixtureLoader
+
+      describe 'when none exists on stripe.com' do
+        let(:headers) { load_request_fixture('stripe_plans_headers_2017.json') }
+        before do
+          Stripe::Plan.stubs(:retrieve).raises(Stripe::InvalidRequestError.new("not found", "id"))
+
+          stub_request(:get, "https://api.stripe.com/v1/plans").
+            with(headers: { 'Authorization'=>'Bearer XYZ',}).
+            to_return(status: 200, body: load_request_fixture('stripe_plans.json'), headers: JSON.parse(headers))
+        end
+
+        it 'creates the plan online' do
+          Stripe::Plan.expects(:create).with(
+            :id => "Solid Gold".to_sym,
+            :currency => 'usd',
+            :name => 'Solid Gold',
+            :amount => 699,
+            :interval => 'month',
+            :interval_count => 1,
+            :trial_period_days => 0
+          )
+          Stripe::Plans::SOLID_GOLD.put!
+        end
+      end
+    end
+  end
 end

--- a/test/plan_builder_spec.rb
+++ b/test/plan_builder_spec.rb
@@ -351,7 +351,7 @@ describe 'building plans' do
     before do
       Stripe.plan "Primo Plan".to_sym do |plan|
         plan.name = 'Acme as a service PRIMO'
-        plan.constant_name = :primo_plan
+        plan.constant_name = 'PRIMO_PLAN'
         plan.amount = 699
         plan.interval = 'month'
         plan.interval_count = 3
@@ -387,7 +387,7 @@ describe 'building plans' do
         lambda {
           Stripe.plan "Primo Plan".to_sym do |plan|
             plan.name = 'Acme as a service PRIMO'
-            plan.constant_name = "Primo Plan".to_sym
+            plan.constant_name = 'PRIMO PLAN'
             plan.amount = 999
             plan.interval = 'month'
           end


### PR DESCRIPTION
As per new addition to Readme this allows: 

"
If you have to support an existing plan with a Stripe plan id that can not
be used as a Ruby constant, provide the plan id as a symbol when
defining the plan, but provide the name for the constant to define with `constant_name`:

```ruby
Stripe.plan "Silver-Plan".to_sym do |plan|
  plan.constant_name = 'SILVER_PLAN'
end

Stripe::Plans::SILVER_PLAN # => will be defined
# Will map to plan :id => "Silver-Plan" on Stripe
```

**Note** - If you're planning on running `rake stripe:prepare` to
  create your subscription plans, Stripe will restrict plan ids to match
  this regexp (`/\A[a-zA-Z0-9_\-]+\z/`) when created via API but still
  allows creation of plan ids that don't follow this restriction when
  manually created on stripe.com.
"

Notes:

- @tansengming What do you think of how it's validating whether `:constant_name` provided can be used as a Ruby constant?  Rails uses regex match in places like `constantize` but this seemed more precise?
- not sure if `master` is the right branch to point against