### PR TITLE
Remove unnecessary require

### DIFF
--- a/app/models/stripe/event_dispatch.rb
+++ b/app/models/stripe/event_dispatch.rb
@@ -1,4 +1,3 @@
-require 'stripe/event'
 module Stripe
   module EventDispatch
     def dispatch_stripe_event(request)


### PR DESCRIPTION
The stripe-ruby gem 4.19.0 changed the directory structure of the entire gem
which causes this require statement to fail. However, the statement
appears to be unnecessary anyways, as it loads just fine without it.
