### PR TITLE
fixes `require` error after stripe gem is updated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,12 @@ env:
   global:
   - GIT_COMMITTED_AT=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then git log -1 --pretty=format:%ct;
     else git log -1 --skip 1 --pretty=format:%ct; fi)
+# https://gist.github.com/tvdeyen/c0ac49c5dbf0e09e305f180d62b067d0
+before_install:
+  - rvm use @global
+  - gem uninstall bundler -x || gem uninstall bundler -a || true
+  - gem install bundler --version=2.0.0
+  - bundler --version
 before_script:
 - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
   > ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
 before_install:
   - rvm use @global
   - gem uninstall bundler -x || gem uninstall bundler -a || true
-  - gem install bundler --version=2.0.0
+  - gem install bundler --version=1.17.3
   - bundler --version
 before_script:
 - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
 - 2.6.0
-- 2.5.3
+- 2.5.5
 - 2.4.5
 - 2.3.8
 addons:
@@ -10,13 +10,6 @@ env:
   global:
   - GIT_COMMITTED_AT=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then git log -1 --pretty=format:%ct;
     else git log -1 --skip 1 --pretty=format:%ct; fi)
-# Note: remove when getting rid of Rails 4.2 testing
-# https://gist.github.com/tvdeyen/c0ac49c5dbf0e09e305f180d62b067d0
-before_install:
-  - rvm use @global
-  - gem uninstall bundler -x || gem uninstall bundler -a || true
-  - yes | gem install bundler --version=1.17.3
-  - bundler --version
 before_script:
 - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
   > ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   global:
   - GIT_COMMITTED_AT=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then git log -1 --pretty=format:%ct;
     else git log -1 --skip 1 --pretty=format:%ct; fi)
+# Note: remove when getting rid of Rails 4.2 testing
 # https://gist.github.com/tvdeyen/c0ac49c5dbf0e09e305f180d62b067d0
 before_install:
   - rvm use @global

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
 before_install:
   - rvm use @global
   - gem uninstall bundler -x || gem uninstall bundler -a || true
-  - gem install bundler --version=1.17.3
+  - yes | gem install bundler --version=1.17.3
   - bundler --version
 before_script:
 - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64

--- a/app/models/stripe/event_dispatch.rb
+++ b/app/models/stripe/event_dispatch.rb
@@ -1,4 +1,3 @@
-require 'stripe/event'
 module Stripe
   module EventDispatch
     def dispatch_stripe_event(request)


### PR DESCRIPTION
thanks to @dark-panda for reporting this at https://github.com/tansengming/stripe-rails/pull/152

this PR also fixes the travis error when it fails to use the correct version of bundler on older versions of rails


<!--
  Please give us ~1 week to get back to you.
  If you'd like to receive occasional updates, sign up for our newsletter at http://tinyletter.com/stripe-rails
-->