### PR TITLE
Updates Rubies for CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.4.x, 2.5.x, 2.6.x, 2.7.x]
+        ruby: [2.4.x, 2.5.x, 2.6.x]
         gemfile: [Gemfile, gemfiles/rails4.gemfile]
 
     steps:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -28,7 +28,7 @@ jobs:
         CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         RUBY_VERSION: ${{ matrix.ruby }}
       run: |
-        gem install bundler -v 1.17.3
+        gem install bundler
         bundle install --jobs 4 --retry 3
         bundle exec rake
         if [ `basename $BUNDLE_GEMFILE` == "Gemfile" ] && [ $RUBY_VERSION == "2.6.x" ] ;

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.3.x, 2.4.x, 2.5.x, 2.6.x]
+        ruby: [2.4.x, 2.5.x, 2.6.x, 2.7.x]
         gemfile: [Gemfile, gemfiles/rails4.gemfile]
 
     steps:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -28,7 +28,8 @@ jobs:
         CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         RUBY_VERSION: ${{ matrix.ruby }}
       run: |
-        gem install bundler
+        gem uninstall bundler
+        gem install bundler -v 1.17.3
         bundle install --jobs 4 --retry 3
         bundle exec rake
         if [ `basename $BUNDLE_GEMFILE` == "Gemfile" ] && [ $RUBY_VERSION == "2.6.x" ] ;

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 
 group :test do
   gem 'mocha'
-  gem 'simplecov', require: false
+  gem 'simplecov', '< 0.18', require: false
   gem 'stripe-ruby-mock'
   gem 'webmock'
   # Required for system tests


### PR DESCRIPTION
Looks like Ruby 2.3 was removed https://github.com/streetsmartslabs/stripe-rails/pull/1/checks?check_run_id=456578641