### PR TITLE
Handle passing nil to signing_secret= and add tests

### DIFF
--- a/lib/stripe/engine.rb
+++ b/lib/stripe/engine.rb
@@ -11,9 +11,9 @@ module Stripe
     stripe_config = config.stripe = Struct.new(:api_base, :api_version, :secret_key, :verify_ssl_certs, :signing_secret, :signing_secrets, :publishable_key, :endpoint, :debug_js, :auto_mount, :eager_load, :open_timeout, :read_timeout) do
       # for backwards compatibility treat signing_secret as an alias for signing_secrets
       def signing_secret=(value)
-        self.signing_secrets = Array(value)
+        self.signing_secrets = value.nil? ? value : Array(value)
       end
-  
+
       def signing_secret
         self.signing_secrets && self.signing_secrets.first
       end

--- a/test/stripe_initializers_spec.rb
+++ b/test/stripe_initializers_spec.rb
@@ -40,7 +40,7 @@ describe "Configuring the stripe engine" do
       app.config.stripe.open_timeout      = 33
       app.config.stripe.read_timeout      = 88
       rerun_initializers!
-    end 
+    end
 
     it "reads values that is set in the environment" do
       subject
@@ -54,6 +54,16 @@ describe "Configuring the stripe engine" do
 
       _(app.config.stripe.signing_secret).must_equal 'SIGNING_SECRET_XYZ'
       _(app.config.stripe.signing_secrets.length).must_equal 1
+    end
+
+    it "supports nil signing_secret" do
+      subject
+
+      app.config.stripe.signing_secret    = nil
+      rerun_initializers!
+
+      _(app.config.stripe.signing_secret).must_equal nil
+      _(app.config.stripe.signing_secrets).must_equal nil
     end
 
     it "supports multiple signing secrets" do


### PR DESCRIPTION
Addresses the issue ["undefined method `data' for []:Array #178"](https://github.com/tansengming/stripe-rails/issues/178) by making sure signing_secrets is set to nil if signing_secret=(nil) is called instead of Array(nil) which returns an empty array.