### PR TITLE
Added option to ignore missing API key and don't show any warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,14 @@ you prefer to environment variables, you can also set `STRIPE_PUBLISHABLE_KEY`:
 export STRIPE_PUBLISHABLE_KEY=pk_test_XXXYYYZZZ
 ```
 
+If no API key is provided, `stripe-rails` will show a warning: "No stripe.com API key was configured ...". You can silence this warning by setting the `ignore_missing_secret_key` option to `true`:
+
+```ruby
+# config/environments/production.rb
+# ...
+config.stripe.ignore_missing_secret_key = true
+```
+
 ### Manually set your API version (optional)
 
 If you need to test a new API version in development, you can override the version number manually.

--- a/lib/stripe/engine.rb
+++ b/lib/stripe/engine.rb
@@ -8,7 +8,7 @@ module Stripe
       attr_accessor :testing
     end
 
-    stripe_config = config.stripe = Struct.new(:api_base, :api_version, :secret_key, :verify_ssl_certs, :signing_secret, :signing_secrets, :publishable_key, :endpoint, :debug_js, :auto_mount, :eager_load, :open_timeout, :read_timeout) do
+    stripe_config = config.stripe = Struct.new(:api_base, :api_version, :secret_key, :ignore_missing_secret_key, :verify_ssl_certs, :signing_secret, :signing_secrets, :publishable_key, :endpoint, :debug_js, :auto_mount, :eager_load, :open_timeout, :read_timeout) do
       # for backwards compatibility treat signing_secret as an alias for signing_secrets
       def signing_secret=(value)
         self.signing_secrets = value.nil? ? value : Array(value)
@@ -43,7 +43,7 @@ module Stripe
       end
       secret_key = app.config.stripe.secret_key
       Stripe.api_key = secret_key unless secret_key.nil?
-      $stderr.puts <<-MSG unless Stripe.api_key || Stripe.ignore_missing_api_key
+      $stderr.puts <<-MSG unless Stripe.api_key || app.config.stripe.ignore_missing_secret_key
 No stripe.com API key was configured for environment #{::Rails.env}! this application will be
 unable to interact with stripe.com. You can set your API key with either the environment
 variable `STRIPE_SECRET_KEY` (recommended) or by setting `config.stripe.secret_key` in your

--- a/lib/stripe/engine.rb
+++ b/lib/stripe/engine.rb
@@ -43,7 +43,7 @@ module Stripe
       end
       secret_key = app.config.stripe.secret_key
       Stripe.api_key = secret_key unless secret_key.nil?
-      $stderr.puts <<-MSG unless Stripe.api_key
+      $stderr.puts <<-MSG unless Stripe.api_key || Stripe.ignore_missing_api_key
 No stripe.com API key was configured for environment #{::Rails.env}! this application will be
 unable to interact with stripe.com. You can set your API key with either the environment
 variable `STRIPE_SECRET_KEY` (recommended) or by setting `config.stripe.secret_key` in your

--- a/test/stripe_initializers_spec.rb
+++ b/test/stripe_initializers_spec.rb
@@ -12,9 +12,10 @@ describe "Configuring the stripe engine" do
   def rerun_initializers!; initializers.each{|init| init.run(app) }; end
 
   after do
-    Stripe.api_version = nil
-    Stripe.api_base    = 'https://api.stripe.com'
-    Stripe.api_key     = 'XYZ'
+    Stripe.api_version       = nil
+    Stripe.api_base          = 'https://api.stripe.com'
+    Stripe.api_key           = 'XYZ'
+    ENV['STRIPE_SECRET_KEY'] = 'XYZ'
   end
 
   describe 'Stripe configurations' do
@@ -98,6 +99,38 @@ describe "Configuring the stripe engine" do
 
     it 'should output a warning' do
       _(-> { subject }).must_output '', warning_msg
+    end
+  end
+
+  describe 'missing stripe.secret_key' do
+    subject do
+      ENV['STRIPE_SECRET_KEY'] = nil
+      Stripe.api_key = nil
+      app.config.stripe.secret_key = nil
+      rerun_initializers!
+    end
+    let(:warning_msg) { /No stripe.com API key was configured for environment test!/ }
+
+    it 'should output a warning' do
+      _(-> { subject }).must_output '', warning_msg
+    end
+  end
+
+  describe 'stripe.ignore_missing_secret_key' do
+    subject do
+      ENV['STRIPE_SECRET_KEY'] = nil
+      Stripe.api_key = nil
+      app.config.stripe.secret_key = nil
+      app.config.stripe.ignore_missing_secret_key = true
+      rerun_initializers!
+    end
+
+    after do
+      app.config.stripe.ignore_missing_secret_key = false
+    end
+
+    it 'should not output a warning' do
+      _(-> { subject }).must_output '', ''
     end
   end
 end


### PR DESCRIPTION
Hello! I have a few deployments and commands where a Stripe API key is not needed, so I wanted to add this option to silence the "No stripe.com API key was configured for environment ..." warning.

Would this be ok? Does `ignore_missing_secret_key` sound alright, or would you prefer something else? Thanks!