### PR TITLE
Description is available for goods and services

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ## Unreleased 2.0.1
 
 - Handle passing nil to signing_secret= and add tests. Thanks @martron!
+- Product descriptions can be set for services and goods. Thanks @jamesprior!
 
 ## 2.0.0 (2020-09-18)
 

--- a/lib/stripe/products.rb
+++ b/lib/stripe/products.rb
@@ -15,14 +15,14 @@ module Stripe
                     :url,
                     :statement_descriptor
 
-      validates_presence_of :name, :type
+      validates_presence_of :name
 
       validates :statement_descriptor, length: { maximum: 22 }
 
       validates :active, :shippable, inclusion: { in: [true, false] }, allow_nil: true
-      validates :type, inclusion: { in: %w(service good) }
-      validates :caption, :shippable, :url, absence: true, unless: :good?
-      validates :statement_descriptor, absence: true, unless: :service?
+      validates :type, inclusion: { in: %w(service good) }, allow_nil: true
+      validates :caption, :description, :shippable, :url, absence: true, if: :service?
+      validates :statement_descriptor, absence: true, if: :good?
 
       private
       def good?

--- a/lib/stripe/products.rb
+++ b/lib/stripe/products.rb
@@ -21,7 +21,7 @@ module Stripe
 
       validates :active, :shippable, inclusion: { in: [true, false] }, allow_nil: true
       validates :type, inclusion: { in: %w(service good) }
-      validates :caption, :description, :shippable, :url, absence: true, unless: :good?
+      validates :caption, :shippable, :url, absence: true, unless: :good?
       validates :statement_descriptor, absence: true, unless: :service?
 
       private

--- a/test/product_builder_spec.rb
+++ b/test/product_builder_spec.rb
@@ -101,5 +101,22 @@ describe 'building products' do
         }).must_raise Stripe::InvalidConfigurationError
       end
     end
+
+    describe 'when type is not set' do
+      it 'accepts service and good attributes' do
+        Stripe.product :primo do |product|
+          product.name        = 'Acme as a service PRIMO'
+          product.active      = true
+          product.attributes  = ['size', 'gender']
+          product.metadata    = {:number_of_awesome_things => 5}
+          product.statement_descriptor = 'PRIMO'
+          product.caption     = 'So good it is Primo'
+          product.description = 'One step beyond supreme'
+          product.shippable   = false
+        end
+
+        _(Stripe::Products::PRIMO).wont_be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
Digging into the Stripe Product API I didn't see where description was listed as only for goods - so I moved it out of the validations for goods only.

The tests are unchanged.  They were not validating description that I saw and given the focused nature of them I wasn't sure that you wanted to carry a spec to ensure Products with descriptions were still valid.
