### PR TITLE
Remove Ping route to non-existant controller

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,5 @@ Rails.application.routes.draw do
 end
 
 Stripe::Engine.routes.draw do
-  resource  :ping, only: :show
   resources :events, only: :create
 end

--- a/test/dummy_apis_controller_spec.rb
+++ b/test/dummy_apis_controller_spec.rb
@@ -9,7 +9,7 @@ describe ApisController do
     header 'Content-Type', 'application/json'
   end
 
-  describe 'the ping interface' do
+  describe 'the apis interface' do
     subject { get '/apis/' }
 
     it { _(subject).must_be :ok? }


### PR DESCRIPTION
Pings controller was removed in https://github.com/tansengming/stripe-rails/commit/72734293db9ac477a95cd3586b50e0d5667b6f3f  but the route remained.

I think there is a test for it too - should that also come out?
