### PR TITLE
Add payment_intent.requires_action callback

### DIFF
--- a/lib/stripe/callbacks.rb
+++ b/lib/stripe/callbacks.rb
@@ -68,6 +68,7 @@ module Stripe
     callback 'payment_intent.created'
     callback 'payment_intent.payment_failed'
     callback 'payment_intent.processing'
+    callback 'payment_intent.requires_action'
     callback 'payment_intent.succeeded'
     callback 'payment_method.attached'
     callback 'payment_method.card_automatically_updated'


### PR DESCRIPTION
Hey there.
This callback seems to be important but is missing:
https://stripe.com/docs/api/events/types#event_types-payment_intent.requires_action
Since a lot of projects need to switch from using Charges to PaymentIntents till the end of 2020 due to the new SCA rules, would be great if we can add it ASAP.
Cheers