### PR TITLE
temporary fix for missing m gem error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,9 @@ gemspec
 
 gem 'rake'
 
-group :development, :test do
-  gem 'm'
-end
+# group :development, :test do
+#   gem 'm'
+# end
 
 group :test do
   gem 'mocha'


### PR DESCRIPTION
```
/opt/hostedtoolcache/Ruby/2.6.6/x64/lib/ruby/2.6.0/bundler/resolver.rb:287:in `block in verify_gemfile_dependencies_are_found!': Could not find gem 'm' in any of the gem sources listed in your Gemfile. (Bundler::GemNotFound)
```

https://github.com/tansengming/stripe-rails/runs/1581853650?check_suite_focus=true