### PR TITLE
Feature - support name attribute in coupons

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,10 +1,11 @@
 ## Unreleased
 
 - Adds testing for Rails 6.0
+- Add `name` attribute to coupons. Thanks @ZilvinasKucinskas!
 
 ## 2.2.1 (2020-12-22)
 
--  Add payment_intent.requires_action callback, thanks @VadimLeader.
+- Add payment_intent.requires_action callback, thanks @VadimLeader.
 
 ## 2.2.0 (2020-12-06)
 

--- a/lib/stripe/coupons.rb
+++ b/lib/stripe/coupons.rb
@@ -3,7 +3,7 @@ module Stripe
     include ConfigurationBuilder
 
     configuration_for :coupon do
-      attr_accessor :duration, :amount_off, :currency, :duration_in_months, :max_redemptions, :percent_off, :redeem_by
+      attr_accessor :name, :duration, :amount_off, :currency, :duration_in_months, :max_redemptions, :percent_off, :redeem_by
 
       validates_presence_of :id, :duration
       validates_presence_of :duration_in_months, :if => :repeating?
@@ -25,6 +25,7 @@ module Stripe
 
       def create_options
         {
+          :name => name,
           :duration => duration,
           :percent_off => percent_off,
           :amount_off => amount_off,

--- a/test/coupon_builder_spec.rb
+++ b/test/coupon_builder_spec.rb
@@ -7,6 +7,7 @@ describe 'building coupons' do
   describe 'default values' do
     before do
       @coupon = Stripe.coupon(:firesale) do |coupon|
+        coupon.name = '100% OFF FIRESALE'
         coupon.duration = 'once'
         coupon.duration_in_months = 100
         coupon.amount_off = 100


### PR DESCRIPTION
[Stripe has an optional `name` parameter while creating coupons](https://stripe.com/docs/api/coupons/create#create_coupon-name). From documentation:

> Name of the coupon displayed to customers on, for instance invoices, or receipts. By default the id is shown if name is not set.

I would like a prettier name such as `20% off, forever` to appear in invoices and receipts and I cannot do it with the id only.

I would appreciate a review and a new release. 🤗

I have updated tests to include this extra attribute. I have also tested by creating some coupons in test Stripe environment with and without `name` parameters by using `gem "stripe-rails", git: "https://github.com/ZilvinasKucinskas/stripe-rails.git", branch: "feature/support-name-in-coupons"` in the Gemfile. It works.