### PR TITLE
Add checkout session expired callback

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+-  Add checkout.session.expired callback. Thanks @danielwellman !
+
 ## 2.3.2 (2021-10-15)
 
 -  Add Subscription Schedule and Tax Rate Callbacks #213 . Thanks @lesliepoolman !

--- a/lib/stripe/callbacks.rb
+++ b/lib/stripe/callbacks.rb
@@ -26,6 +26,7 @@ module Stripe
     callback 'charge.dispute.updated'
     callback 'charge.refund.updated'
     callback 'checkout.session.completed'
+    callback 'checkout.session.expired'
     callback 'coupon.created'
     callback 'coupon.deleted'
     callback 'coupon.updated'


### PR DESCRIPTION
Add the checkout.session.expired callback.  See https://stripe.com/docs/api/events/types#event_types-checkout.session.expired