### PR TITLE
Problem: NameError when loading JavascriptHelper

### DIFF
--- a/lib/stripe/engine.rb
+++ b/lib/stripe/engine.rb
@@ -1,4 +1,6 @@
 require 'stripe'
+require_relative '../../app/helpers/stripe/javascript_helper.rb'
+
 
 module Stripe
   class Engine < ::Rails::Engine


### PR DESCRIPTION
I've encountered the problem while upgrading to Rails 7 and found this solution in one of the issues (#168). Don't think this is the best solution but it got me past the problem. Any suggestions on how we can fix this better?

<!--
  Thanks a bunch for helping out with the project!

  Please remember to,

  1. Add tests if they do not exist, fix em if they are breaking
  2. Fix any issues that are stopping Code Climate from passing
  2. Add a short description of the feature and tag yourself on Changelog.md

  That's it!

  Please give me ~1 week to get back to you.

  If you'd like to receive occasional updates, sign up for our newsletter at http://tinyletter.com/stripe-rails
-->