### PR TITLE
Fix deprecation warnings + Fix autoload warning

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- Fix some deprecation warnings in tests. Thanks @smtlaissezfaire !
+- Fix `NameError when loading JavascriptHelper`. Thanks @smtlaissezfaire !
+
 ## 2.3.4 (2022-05-03)
 
 -  Add setup_intent.canceled and setup_intent.requires_action callbacks. Thanks @jamesjason !

--- a/lib/stripe/engine.rb
+++ b/lib/stripe/engine.rb
@@ -79,7 +79,7 @@ environment file directly.
       end
     end
 
-    initializer 'stripe.javascript_helper' do
+    config.to_prepare do
       ActiveSupport.on_load :action_controller do
         # ActionController::API does not have a helper method
         if respond_to?(:helper)

--- a/test/plan_builder_spec.rb
+++ b/test/plan_builder_spec.rb
@@ -307,7 +307,7 @@ describe 'building plans' do
 
           describe 'when passed invalid arguments for tiered pricing' do
             it 'raises a Stripe::InvalidConfigurationError when billing tiers are invalid' do
-              lambda {
+              _(lambda {
                 Stripe.plan "Bad Tiers".to_sym do |plan|
                   plan.name = 'Acme as a service BAD TIERS'
                   plan.constant_name = 'BAD_TIERS'
@@ -328,11 +328,11 @@ describe 'building plans' do
                     }
                   ]
                 end
-              }.must_raise Stripe::InvalidConfigurationError
+              }).must_raise Stripe::InvalidConfigurationError
             end
 
             it 'raises a Stripe::InvalidConfigurationError when billing tiers is not an array' do
-              lambda {
+              _(lambda {
                 Stripe.plan "Bad Tiers".to_sym do |plan|
                   plan.name = 'Acme as a service BAD TIERS'
                   plan.constant_name = 'BAD_TIERS'
@@ -348,7 +348,7 @@ describe 'building plans' do
                     up_to: 10
                   }
                 end
-              }.must_raise Stripe::InvalidConfigurationError
+              }).must_raise Stripe::InvalidConfigurationError
             end
           end
 

--- a/test/price_builder_spec.rb
+++ b/test/price_builder_spec.rb
@@ -392,7 +392,7 @@ describe 'building prices' do
 
         describe 'when passed invalid arguments for tiered pricing' do
           it 'raises a Stripe::InvalidConfigurationError when billing tiers are invalid' do
-            lambda {
+            _(lambda {
               Stripe.price "Bad Tiers".to_sym do |price|
                 price.name = 'Acme as a service BAD TIERS'
                 price.constant_name = 'BAD_TIERS'
@@ -414,11 +414,11 @@ describe 'building prices' do
                   }
                 ]
               end
-            }.must_raise Stripe::InvalidConfigurationError
+            }).must_raise Stripe::InvalidConfigurationError
           end
 
           it 'raises a Stripe::InvalidConfigurationError when billing tiers is not an array' do
-            lambda {
+            _(lambda {
               Stripe.price "Bad Tiers".to_sym do |price|
                 price.name = 'Acme as a service BAD TIERS'
                 price.constant_name = 'BAD_TIERS'
@@ -435,7 +435,7 @@ describe 'building prices' do
                   up_to: 10
                 }
               end
-            }.must_raise Stripe::InvalidConfigurationError
+            }).must_raise Stripe::InvalidConfigurationError
           end
         end
 

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -34,6 +34,6 @@ if ActiveSupport::TestCase.method_defined?(:fixture_path=)
 end
 
 Stripe::Engine.testing = true
-require 'mocha/setup'
+require 'mocha/minitest'
 
 require 'irb'

--- a/test/stripe_initializers_spec.rb
+++ b/test/stripe_initializers_spec.rb
@@ -4,12 +4,18 @@ describe "Configuring the stripe engine" do
   i_suck_and_my_tests_are_order_dependent! # the default test must be run first!
 
   # NOTE: skipped `stripe.plans_and_coupons` to prevent warnings about constants
-  STRIPE_INITIALIZER_NAMES = %w{ stripe.configure.defaults stripe.configure stripe.callbacks.eager_load stripe.javascript_helper }
+  STRIPE_INITIALIZER_NAMES = %w{
+    stripe.configure.defaults
+    stripe.configure
+    stripe.callbacks.eager_load
+  }
 
   let(:app)           { Rails.application }
   let(:initializers)  { STRIPE_INITIALIZER_NAMES.map{|name| app.initializers.find{|ini| ini.name == name } } }
 
-  def rerun_initializers!; initializers.each{|init| init.run(app) }; end
+  def rerun_initializers!
+    initializers.each { |init| init.run(app) }
+  end
 
   after do
     Stripe.api_version       = nil

--- a/test/stripe_initializers_spec.rb
+++ b/test/stripe_initializers_spec.rb
@@ -60,11 +60,11 @@ describe "Configuring the stripe engine" do
     it "supports nil signing_secret" do
       subject
 
-      app.config.stripe.signing_secret    = nil
+      app.config.stripe.signing_secret = nil
       rerun_initializers!
 
-      _(app.config.stripe.signing_secret).must_equal nil
-      _(app.config.stripe.signing_secrets).must_equal nil
+      assert_nil app.config.stripe.signing_secret
+      assert_nil app.config.stripe.signing_secrets
     end
 
     it "supports multiple signing secrets" do


### PR DESCRIPTION
* Fix some warnings when running test suite
* Fix issue found in https://github.com/tansengming/stripe-rails/pull/217 (`DEPRECATION WARNING: Initialization autoloaded the constant Stripe::JavascriptHelper.`)