### PR TITLE
Respect plan ID case when constant not defined

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Allow mixed case plan IDs. Thanks @swebb !
+
 ## 2.4.0 (2023-02-04)
 
 - Add `tax_behavior` attribute to Price. Thanks @szechyjs !

--- a/lib/stripe/configuration_builder.rb
+++ b/lib/stripe/configuration_builder.rb
@@ -68,9 +68,9 @@ module Stripe
       end
 
       def globalize!
-        id_to_use = @constant_name || @id
-        @stripe_configuration_class[id_to_use.to_s.downcase] = self
-        @stripe_configuration_class.const_set(id_to_use.to_s.upcase, self)
+        id_to_use = @constant_name ? @constant_name.to_s.downcase : @id.to_s
+        @stripe_configuration_class[id_to_use] = self
+        @stripe_configuration_class.const_set(id_to_use.upcase, self)
       end
 
       def put!

--- a/test/plan_builder_spec.rb
+++ b/test/plan_builder_spec.rb
@@ -35,6 +35,33 @@ describe 'building plans' do
       _(Stripe::Plans['primo']).must_equal Stripe::Plans::PRIMO
     end
 
+    describe "plan ID includes upper case letters" do
+      before do
+        Stripe.plan :mixed_CASE do |plan|
+          plan.name = 'Acme as a service mixed CASE'
+          plan.amount = 699
+          plan.interval = 'month'
+          plan.interval_count = 3
+          plan.trial_period_days = 30
+          plan.metadata = {:number_of_awesome_things => 5}
+          plan.statement_descriptor = 'Acme mixed CASE'
+          plan.active = true
+          plan.nickname = 'mixedcase'
+          plan.usage_type = 'metered'
+          plan.billing_scheme = 'per_unit'
+          plan.aggregate_usage = 'sum'
+          plan.tiers_mode = 'graduated'
+        end
+      end
+
+      after { Stripe::Plans.send(:remove_const, :MIXED_CASE) }
+
+      it 'is case sensitive' do
+        _(Stripe::Plans[:mixed_CASE]).must_equal Stripe::Plans::MIXED_CASE
+        _(Stripe::Plans['mixed_CASE']).must_equal Stripe::Plans::MIXED_CASE
+      end
+    end
+
     it 'accepts a billing interval of a day' do
       Stripe.plan :daily do |plan|
         plan.name = 'Acme as a service daily'


### PR DESCRIPTION
Prior to 1.6.2 the plan ID could have mixed case characters. From 1.6.2 onwards the plan ID is downcased which causes lookup misses. This PR restores the original behaviour when the constant name isn't defined.

The original change as in https://github.com/tansengming/stripe-rails/commit/ada910de738945ad7855d35b7b4e383234592a05
