### PR TITLE
Allow stripe_elements_tag to accept a block

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## 2.5.0 (2023-03-21)
+
+- Allow `stripe_elements_tag` to accept a block. Thanks @chip !
+
 ## 2.4.0 (2023-02-04)
 
 - Add `tax_behavior` attribute to Price. Thanks @szechyjs !

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This gem can help your rails application integrate with Stripe in the following 
 - [Configuring your plans and coupons](#configuring-your-plans-and-coupons)
 
 [Stripe Elements](#stripe-elements)
+- [Custom Elements](#custom-elements)
 
 [Webhooks](#webhooks)
 
@@ -318,6 +319,22 @@ Simply include the `stripe_elements_tag` anywhere below the `stripe_javascript_t
 ```erb
 <%= stripe_javascript_tag %>
 <%= stripe_elements_tag submit_path: billing_path %>
+```
+
+Additionally, you can pass a block containing custom form elements to stripe_elements_tag:
+
+## Custom Elements
+
+> Stripe::Rails allows you to easily include your own custom form elements
+> within the Stripe form by including those form elements in a block passed to
+> `stripe_elements_tag`:
+
+```erb
+<%= stripe_javascript_tag %>
+<%= stripe_elements_tag(submit_path: billing_path) do %>
+  <%= label_tag 'email', 'Email' %>
+  <%= text_field :user, :email %>
+<% end %>
 ```
 
 ### Configuration options

--- a/app/helpers/stripe/javascript_helper.rb
+++ b/app/helpers/stripe/javascript_helper.rb
@@ -10,14 +10,16 @@ module Stripe
 
     def stripe_elements_tag(submit_path:,
                             css_path: asset_path("stripe_elements.css"),
-                            js_path: asset_path("stripe_elements.js"))
+                            js_path: asset_path("stripe_elements.js"),
+                            &block)
 
       render partial: 'stripe/elements', locals: {
         submit_path: submit_path,
         label_text: t('stripe_rails.elements.label_text'),
         submit_button_text: t('stripe_rails.elements.submit_button_text'),
         css_path: css_path,
-        js_path: js_path
+        js_path: js_path,
+        block: block
       }
     end
   end

--- a/app/views/stripe/_elements.html.erb
+++ b/app/views/stripe/_elements.html.erb
@@ -5,6 +5,11 @@
   </div>
 
   <%= form_tag submit_path, id: "stripe-form" do %>
+    <% if local_assigns[:block] %>
+      <div id="stripe-rails-form-fields">
+        <%= capture(&local_assigns[:block]) %>
+      </div>
+    <% end %>
     <%= label_tag :card_element, label_text %>
     <div id="card-element"><!-- A Stripe Element will be inserted here. --></div>
     <%= submit_tag submit_button_text %>

--- a/lib/stripe/rails/version.rb
+++ b/lib/stripe/rails/version.rb
@@ -1,5 +1,5 @@
 module Stripe
   module Rails
-    VERSION = '2.4.0'.freeze
+    VERSION = '2.5.0'.freeze
   end
 end

--- a/test/javascript_helper_spec.rb
+++ b/test/javascript_helper_spec.rb
@@ -77,5 +77,15 @@ describe Stripe::JavascriptHelper do
         end
       end
     end
+
+    describe 'with block' do
+      let(:markup)      { '<input type="text" />'.html_safe }
+
+      it 'should display block contents' do
+        block = lambda { markup }
+        result = view.stripe_elements_tag(submit_path: '/charge', &block)
+        assert_match %r%<input type="text" />%, result
+      end
+    end
   end
 end


### PR DESCRIPTION
Hello and thanks for creating this gem!

I needed to pass some form fields to `stripe_elements_tag`, so I've implemented it here. The `Gemfile` and `test/spec_helper.rb` changes were to simply get the tests to pass.

I'm happy to make changes if there's a better way. I hope you find this useful.