### PR TITLE
Fix: replace deprecated Request#[] with request.params[]

### DIFF
--- a/app/models/stripe/event_dispatch.rb
+++ b/app/models/stripe/event_dispatch.rb
@@ -8,7 +8,7 @@ module Stripe
     end
 
     def retrieve_stripe_event(request)
-      id = request['id']
+      id = request.params['id']
       body = request.body.read
       sig_header = request.headers['HTTP_STRIPE_SIGNATURE']
       endpoint_secrets = ::Rails.application.config.stripe.signing_secrets


### PR DESCRIPTION

Fixes https://github.com/tansengming/stripe-rails/issues/230

Investigation: https://github.com/tansengming/stripe-rails/pull/231/files#r1698713160