### PR TITLE
Fix product reference in price builder

### DIFF
--- a/lib/stripe/prices.rb
+++ b/lib/stripe/prices.rb
@@ -126,7 +126,7 @@ module Stripe
       end
 
       def name_or_product_id
-        errors.add(:base, 'must have a product_id or a name') unless (@product_id.present? ^ @name.present?)
+        errors.add(:base, 'must have a product_id or a name') unless (@product_id.present? || @name.present?)
       end
 
       def billing_scheme_must_be_tiered

--- a/test/price_builder_spec.rb
+++ b/test/price_builder_spec.rb
@@ -647,4 +647,30 @@ describe 'building prices' do
       end
     end
   end
+
+  describe 'referencing a product' do
+    before do
+      Stripe.product :free do |product|
+        product.name = "Free"
+        product.type = "service"
+      end
+    end
+
+    it 'works just fine' do
+      Stripe.price :free do |price|
+        price.name = "Free Price"
+        price.product_id = Stripe::Products::FREE.id
+        price.unit_amount = 0
+        price.currency = "usd"
+        price.recurring = {
+          interval: "month",
+          interval_count: 1,
+          usage_type: "licensed",
+          aggregate_usage: nil
+        }
+      end
+
+      expect(Stripe::Prices::FREE.product_id).to eq Stripe::Products::FREE.id
+    end
+  end
 end


### PR DESCRIPTION
Fixes an issue causing dynamic product referencing not work when defining prices.

Reported issue:
https://github.com/tansengming/stripe-rails/issues/235